### PR TITLE
[Fix] TextArea height 늘어나지 않는 버그 수정

### DIFF
--- a/src/components/common/TextField/TextField.css.ts
+++ b/src/components/common/TextField/TextField.css.ts
@@ -19,6 +19,7 @@ export const textFieldContainer = style({
 export const textInput = recipe({
   base: {
     width: '100%',
+    height: '100%',
     '::placeholder': {
       color: palette.gray300
     }


### PR DESCRIPTION
## 스크린샷

### 버그 화면
https://github.com/YAPP-Github/22nd-Web-Team-2-Web/assets/66112027/a5bef0a1-3638-417e-9fa7-b069d416711d


### 버그 수정 화면
https://github.com/YAPP-Github/22nd-Web-Team-2-Web/assets/66112027/03fa7dc7-7f1b-4180-b1bb-dd3d28f72889


<br>

## Motivation

- <textArea /> 에 적용되는 클래스에 height:100%를 추가했습니다.

