### PR TITLE
[Feat] 봉사 모집 일정 수정 구현

### DIFF
--- a/src/api/shelter/admin/useAdminVolunteerEvent.ts
+++ b/src/api/shelter/admin/useAdminVolunteerEvent.ts
@@ -1,0 +1,16 @@
+import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import { queryKey, get } from './volunteer-event';
+import { VolunteerEventDetail } from '@/types/volunteerEvent';
+
+export default function useAdminVolunteerEvent(
+  eventId: number,
+  options?: UseQueryOptions<VolunteerEventDetail>
+) {
+  return useQuery<VolunteerEventDetail>(
+    queryKey.detail(eventId),
+    () => get(eventId),
+    {
+      ...options
+    }
+  );
+}

--- a/src/api/shelter/admin/volunteer-event.ts
+++ b/src/api/shelter/admin/volunteer-event.ts
@@ -4,6 +4,12 @@ import {
   IterationCycle,
   VolunteerEventCategory
 } from '@/constants/volunteerEvent';
+import { VolunteerEventDetail } from '@/types/volunteerEvent';
+
+export const queryKey = {
+  all: ['admin-volunteer-event'] as const,
+  detail: (eventId: number) => [...queryKey.all, eventId]
+};
 
 export type VolunteerEventPayload = {
   title: string;
@@ -48,4 +54,10 @@ export const remove = async (id: number) => {
   return await api
     .delete(`shelter/admin/volunteer-event/${id}`)
     .json<DeleteResponse>();
+};
+
+export const get = async (id: number) => {
+  return await api
+    .get(`shelter/admin/volunteer-event/${id}`)
+    .json<VolunteerEventDetail>();
 };

--- a/src/api/shelter/admin/volunteer-event.ts
+++ b/src/api/shelter/admin/volunteer-event.ts
@@ -4,14 +4,14 @@ import {
   IterationCycle,
   VolunteerEventCategory
 } from '@/constants/volunteerEvent';
-import { VolunteerEventDetail } from '@/types/volunteerEvent';
+import { EventStatus, VolunteerEventDetail } from '@/types/volunteerEvent';
 
 export const queryKey = {
   all: ['admin-volunteer-event'] as const,
   detail: (eventId: number) => [...queryKey.all, eventId]
 };
 
-export type VolunteerEventPayload = {
+export interface VolunteerEventPayload {
   title: string;
   recruitNum: number;
   description: string;
@@ -23,7 +23,12 @@ export type VolunteerEventPayload = {
     iterationCycle: IterationCycle;
     iterationEndAt: string; //yyyy-MM-dd
   } | null;
-};
+}
+
+export interface PutVolunteerEventPayload
+  extends Omit<VolunteerEventPayload, 'iteration'> {
+  status: EventStatus;
+}
 
 export type PostResponse = {
   volunteerEventsId: number[];
@@ -39,7 +44,7 @@ export const post = async (payload: VolunteerEventPayload) => {
 export type PutResponse = {
   volunteerEventId: number;
 };
-export const put = async (id: number, payload: VolunteerEventPayload) => {
+export const put = async (id: number, payload: PutVolunteerEventPayload) => {
   return await api
     .put(`shelter/admin/volunteer-event/${id}`, {
       json: payload

--- a/src/components/shelter/shelter-event/ShelterEvent.tsx
+++ b/src/components/shelter/shelter-event/ShelterEvent.tsx
@@ -207,7 +207,9 @@ export default function ShelterEvent() {
 
         <Button
           style={{ marginTop: 1 }}
-          onClick={() => route.push(`${pathname}/edit`)}
+          onClick={() =>
+            route.push(`/admin/shelter/event/edit?id=${volunteerEventId}`)
+          }
         >
           일정 수정하기
         </Button>

--- a/src/types/volunteerEvent.ts
+++ b/src/types/volunteerEvent.ts
@@ -1,4 +1,5 @@
-import { VolunteerEventCategory } from '@/constants/volunteerEvent';
+import { AgeLimit, VolunteerEventCategory } from '@/constants/volunteerEvent';
+import { ShelterAddress } from './shelter';
 
 export type EventStatus = 'IN_PROGRESS' | 'DONE' | 'CANCELED';
 export type MyParticipationStatus = 'PARTICIPATING' | 'WAITING' | 'NONE';
@@ -14,4 +15,18 @@ export interface VolunteerEvent {
   startAt: string;
   endAt: string;
   myParticipationStatus?: MyParticipationStatus;
+}
+
+export interface VolunteerEventDetail extends VolunteerEvent {
+  shelterName: string;
+  shelterProfileImageUrl: string;
+  title: string;
+  description: string;
+  address: ShelterAddress;
+  joiningVolunteers: string[];
+  waitingVolunteers: string[];
+  ageLimit: AgeLimit;
+  category: VolunteerEventCategory;
+  eventStatus: EventStatus;
+  myParticipationStatus: MyParticipationStatus;
 }


### PR DESCRIPTION

## Motivation

- [YW2-126](https://yapp22-web2.atlassian.net/browse/YW2-126)
- 일정 생성 페이지에 수정 기능 추가

<br>

## To Reviewers

- id 쿼리 파라미터를 붙여서 해당 이벤트를 가져오고 수정할 수 있습니다
- 중복 선언된 인터페이스가 있어요 추후 정리가 필요합니다 (`VolunteerEvent` 등)

### Key Changes
- 일정 수정 시 원래 데이터 받아와서 폼 초기화하기
- shelter admin 이벤트 상세 받아오기 api
- useAdminVolunteerEvent 쿼리 훅
- 일정 수정 api 연동