### PR TITLE
[Feat] Skeleton / Filter UI 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { GlobalComponents } from '@/components/global/GlobalComponents/GlobalCom
 import Header from '@/components/common/Header/Header';
 import { AuthProvider } from '@/providers/AuthContext';
 import Footer from '@/components/common/Footer/Footer';
+import ScrollToTop from '@/components/global/ScrollToTop/ScrollToTop';
 
 export const metadata = {
   title: 'Create Next App',
@@ -27,7 +28,9 @@ export default function RootLayout({
               <div id="modal-portal" />
               <GlobalComponents />
               <Header />
-              <main className={styles.main}>{children}</main>
+              <ScrollToTop>
+                <main className={styles.main}>{children}</main>
+              </ScrollToTop>
               <Footer />
             </AuthProvider>
           </QueryProvider>

--- a/src/asset/icons/DropArrow.svg
+++ b/src/asset/icons/DropArrow.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 6.66666L8 10.6667L12 6.66666" stroke="#333333" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/asset/icons/Phone.svg
+++ b/src/asset/icons/Phone.svg
@@ -1,0 +1,3 @@
+<svg width="45" height="4" viewBox="0 0 45 4" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" width="44" height="4" rx="2" fill="#E8E8E8"/>
+</svg>

--- a/src/asset/icons/index.ts
+++ b/src/asset/icons/index.ts
@@ -32,3 +32,5 @@ export { default as Delete } from './Delete.svg';
 export { default as Calendar } from './Calendar.svg';
 export { default as Clockmd } from './Clockmd.svg';
 export { default as Profilemd } from './Profilemd.svg';
+export { default as DropArrow } from './DropArrow.svg';
+export { default as Phone } from './Phone.svg';

--- a/src/components/common/BottomSheet/BottomSheet.css.ts
+++ b/src/components/common/BottomSheet/BottomSheet.css.ts
@@ -31,3 +31,9 @@ export const overlay = style({
 export const childrenWrap = style({
   marginTop: '40px'
 });
+
+export const phoneWrap = style({
+  display: 'flex',
+  justifyContent: 'center',
+  paddingTop: '8px'
+});

--- a/src/components/common/BottomSheet/BottomSheet.css.ts
+++ b/src/components/common/BottomSheet/BottomSheet.css.ts
@@ -7,8 +7,7 @@ export const bottomSheetLeft = createVar('bottomSheetLeft');
 export const panel = style({
   position: 'fixed',
   bottom: -5,
-  left: [bottomSheetLeft],
-  height: '560px',
+  left: bottomSheetLeft,
   borderRadius: '20px 20px 0px 0px',
   width: '100%',
   maxWidth: BREAK_POINT,
@@ -29,7 +28,7 @@ export const overlay = style({
 });
 
 export const childrenWrap = style({
-  marginTop: '40px'
+  marginTop: '20px'
 });
 
 export const phoneWrap = style({

--- a/src/components/common/BottomSheet/BottomSheet.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.tsx
@@ -5,6 +5,7 @@ import * as m from '@/components/global/Dialog/utils/motion';
 import clsx from 'clsx';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import { BREAK_POINT } from '@/styles/global.css';
+import { Phone } from '@/asset/icons';
 
 interface BottomSheetProps {
   /** bottom sheet status */
@@ -67,6 +68,9 @@ export default function BottomSheet({
             animate="visible"
             exit="leaving"
           >
+            <div className={styles.phoneWrap}>
+              <Phone />
+            </div>
             <div className={styles.childrenWrap}>{children}</div>
           </motion.section>
         </>

--- a/src/components/common/Filter/Filter.css.ts
+++ b/src/components/common/Filter/Filter.css.ts
@@ -1,0 +1,46 @@
+import { palette } from '@/styles/color';
+import { BREAK_POINT, GLOBAL_PADDING_X } from '@/styles/global.css';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const container = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '6px 8px 6px 12px',
+  borderRadius: '35px',
+  border: `1px solid ${palette.gray800}`,
+  cursor: 'pointer'
+});
+
+export const grid = style({
+  display: 'flex',
+  gap: '4px'
+});
+export const sheet = style({
+  backgroundColor: `${palette.white} !important`
+});
+export const sheetContainer = style({
+  padding: '0 24px 24px 24px',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center'
+});
+export const label = style({
+  padding: '9px 248px 9px 0px',
+  width: `calc(100% - ${GLOBAL_PADDING_X}px)`,
+  maxWidth: BREAK_POINT,
+  borderBottom: `1px solid ${palette.gray100}`
+});
+export const labelTxt = recipe({
+  base: {},
+  variants: {
+    color: {
+      pick: {
+        color: palette.gray900
+      },
+      option: {
+        color: palette.gray400
+      }
+    }
+  }
+});

--- a/src/components/common/Filter/Filter.css.ts
+++ b/src/components/common/Filter/Filter.css.ts
@@ -1,7 +1,5 @@
 import { palette } from '@/styles/color';
-import { BREAK_POINT, GLOBAL_PADDING_X } from '@/styles/global.css';
 import { style } from '@vanilla-extract/css';
-import { recipe } from '@vanilla-extract/recipes';
 
 export const container = style({
   display: 'inline-flex',
@@ -9,38 +7,13 @@ export const container = style({
   padding: '6px 8px 6px 12px',
   borderRadius: '35px',
   border: `1px solid ${palette.gray800}`,
-  cursor: 'pointer'
+  cursor: 'pointer',
+  ':hover': {
+    backgroundColor: palette.gray200
+  }
 });
 
 export const grid = style({
   display: 'flex',
   gap: '4px'
-});
-export const sheet = style({
-  backgroundColor: `${palette.white} !important`
-});
-export const sheetContainer = style({
-  padding: '0 24px 24px 24px',
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center'
-});
-export const label = style({
-  padding: '9px 248px 9px 0px',
-  width: `calc(100% - ${GLOBAL_PADDING_X}px)`,
-  maxWidth: BREAK_POINT,
-  borderBottom: `1px solid ${palette.gray100}`
-});
-export const labelTxt = recipe({
-  base: {},
-  variants: {
-    color: {
-      pick: {
-        color: palette.gray900
-      },
-      option: {
-        color: palette.gray400
-      }
-    }
-  }
 });

--- a/src/components/common/Filter/Filter.tsx
+++ b/src/components/common/Filter/Filter.tsx
@@ -1,0 +1,70 @@
+'use client';
+import { DropArrow } from '@/asset/icons';
+import useBooleanState from '@/hooks/useBooleanState';
+import { useState } from 'react';
+import BottomSheet from '../BottomSheet/BottomSheet';
+import { Body3, Body4, Caption3 } from '../Typography';
+import * as styles from './Filter.css';
+
+interface FilterProps {
+  label: string;
+}
+
+const option = [
+  { label: '전체', value: 'ALL' },
+  { label: '모집중', value: 'IN_PROGRESS' },
+  { label: '모집 종료', value: 'DONE' }
+];
+
+export default function Filter({ label }: FilterProps) {
+  const [isFilter, openFilter, closeFilter] = useBooleanState();
+  const [searchData, setSearchData] = useState(option[0].label);
+
+  return (
+    <>
+      <button
+        className={styles.container}
+        onClick={() => {
+          openFilter();
+        }}
+      >
+        <div className={styles.grid}>
+          <Caption3>
+            {label} · {searchData}
+          </Caption3>
+          <DropArrow />
+        </div>
+      </button>
+
+      <BottomSheet
+        isOpened={isFilter}
+        onClose={closeFilter}
+        className={styles.sheet}
+      >
+        <section className={styles.sheetContainer}>
+          <Body3 style={{ textAlign: 'center' }}>{label}</Body3>
+          <ul>
+            {option?.map(({ label, value }) => (
+              <li
+                key={value}
+                className={styles.label}
+                onClick={() => {
+                  setSearchData(label);
+                  closeFilter();
+                }}
+              >
+                <Body4
+                  className={styles.labelTxt({
+                    color: label === searchData ? 'pick' : 'option'
+                  })}
+                >
+                  {label}
+                </Body4>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </BottomSheet>
+    </>
+  );
+}

--- a/src/components/common/Filter/Filter.tsx
+++ b/src/components/common/Filter/Filter.tsx
@@ -1,70 +1,73 @@
 'use client';
 import { DropArrow } from '@/asset/icons';
 import useBooleanState from '@/hooks/useBooleanState';
-import { useState } from 'react';
-import BottomSheet from '../BottomSheet/BottomSheet';
-import { Body3, Body4, Caption3 } from '../Typography';
+import { useCallback, useState } from 'react';
+import { Caption3 } from '../Typography';
 import * as styles from './Filter.css';
-
-interface FilterProps {
+import FilterBottom from './FilterBottom';
+export interface FilterOption {
   label: string;
+  value: string;
+}
+interface FilterProps {
+  name: string;
+  label: string;
+  options: FilterOption[];
+  onChange: (name: string, value: string) => void;
 }
 
-const option = [
-  { label: '전체', value: 'ALL' },
-  { label: '모집중', value: 'IN_PROGRESS' },
-  { label: '모집 종료', value: 'DONE' }
-];
+/**
+ * `Filter` 컴포넌트는 필터 옵션을 선택할 수 있는 바텀시트를 제공합니다.
+ * 선택한 필터 옵션 값에 따라 처리 로직을 수행하려면 `onChange` prop에 콜백 함수를 전달해야 합니다.
+ *
+ * @component
+ * @example
+ * <Filter
+ *   name="region"
+ *   label="지역"
+ *   options={option_region}
+ *   onChange={handleSearchData}
+ * />
+ * @param name 필터에서 선택한 옵션 값을 처리하는 onChange 로직에서 구분자 역할을 합니다.
+ * @param label 필터 UI에 표시되는 텍스트입니다.
+ * @param options 선택할 수 있는 필터 옵션들의 배열입니다.
+ * @param onChange 필터 값을 변경할 때 호출되는 콜백 함수입니다. 필터 name과 선택된 option의 value 값이 인자로 전달됩니다.
+ */
 
-export default function Filter({ label }: FilterProps) {
+const Filter = ({ name, label, options, onChange }: FilterProps) => {
   const [isFilter, openFilter, closeFilter] = useBooleanState();
-  const [searchData, setSearchData] = useState(option[0].label);
+  const [pickOption, setPickOption] = useState(options[0]?.label);
+
+  const handleChangeData = useCallback(
+    (label: string, value: string) => {
+      setPickOption(label);
+      onChange(name, value);
+      closeFilter();
+    },
+    [name, onChange, closeFilter]
+  );
 
   return (
     <>
-      <button
-        className={styles.container}
-        onClick={() => {
-          openFilter();
-        }}
-      >
+      <button className={styles.container} onClick={openFilter}>
         <div className={styles.grid}>
           <Caption3>
-            {label} · {searchData}
+            {label} · {pickOption}
           </Caption3>
           <DropArrow />
         </div>
       </button>
 
-      <BottomSheet
-        isOpened={isFilter}
+      <FilterBottom
+        open={isFilter}
         onClose={closeFilter}
-        className={styles.sheet}
-      >
-        <section className={styles.sheetContainer}>
-          <Body3 style={{ textAlign: 'center' }}>{label}</Body3>
-          <ul>
-            {option?.map(({ label, value }) => (
-              <li
-                key={value}
-                className={styles.label}
-                onClick={() => {
-                  setSearchData(label);
-                  closeFilter();
-                }}
-              >
-                <Body4
-                  className={styles.labelTxt({
-                    color: label === searchData ? 'pick' : 'option'
-                  })}
-                >
-                  {label}
-                </Body4>
-              </li>
-            ))}
-          </ul>
-        </section>
-      </BottomSheet>
+        label={label}
+        options={options}
+        pickOption={pickOption}
+        onClick={handleChangeData}
+      />
     </>
   );
-}
+};
+
+export default Filter;

--- a/src/components/common/Filter/FilterBottom.css.ts
+++ b/src/components/common/Filter/FilterBottom.css.ts
@@ -1,0 +1,47 @@
+import { palette } from '@/styles/color';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const sheet = style({
+  backgroundColor: `${palette.white} !important`
+});
+
+export const sheetContainer = style({
+  padding: '0 24px 48px 24px',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center'
+});
+
+export const title = style({
+  textAlign: 'center',
+  padding: '4px 0 18px 0'
+});
+
+export const label = style({
+  padding: '9px 248px 9px 0px',
+  borderBottom: `1px solid ${palette.gray100}`,
+  ':hover': {
+    backgroundColor: palette.gray100
+  }
+});
+
+export const labelTxt = recipe({
+  base: {
+    width: '100%',
+    lineHeight: 'inherit',
+    ':hover': {
+      color: palette.gray600
+    }
+  },
+  variants: {
+    color: {
+      pick: {
+        color: palette.gray900
+      },
+      other: {
+        color: palette.gray400
+      }
+    }
+  }
+});

--- a/src/components/common/Filter/FilterBottom.tsx
+++ b/src/components/common/Filter/FilterBottom.tsx
@@ -1,0 +1,47 @@
+import BottomSheet from '../BottomSheet/BottomSheet';
+import { Body3, Body4 } from '../Typography';
+import { FilterOption } from './Filter';
+import * as styles from './FilterBottom.css';
+
+interface FilterBottomProps {
+  open: boolean;
+  onClose: VoidFunction;
+  label: string;
+  options: FilterOption[];
+  pickOption: string;
+  onClick: (label: string, value: string) => void;
+}
+
+export default function FilterBottom({
+  open,
+  onClose,
+  label,
+  options,
+  pickOption,
+  onClick
+}: FilterBottomProps) {
+  return (
+    <BottomSheet isOpened={open} onClose={onClose} className={styles.sheet}>
+      <section className={styles.sheetContainer}>
+        <Body3 className={styles.title}>{label}</Body3>
+        <ul>
+          {options?.map(({ label, value }) => (
+            <li
+              key={value}
+              className={styles.label}
+              onClick={() => onClick(label, value)}
+            >
+              <Body4
+                className={styles.labelTxt({
+                  color: label === pickOption ? 'pick' : 'other'
+                })}
+              >
+                {label}
+              </Body4>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </BottomSheet>
+  );
+}

--- a/src/components/common/Filter/example.tsx
+++ b/src/components/common/Filter/example.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Filter from './Filter';
+
+export default function FilterExample() {
+  // state로 관리
+  const [searchData, setSearchData] = useState({
+    region: option_region[0].value,
+    category: ''
+  });
+
+  const handleSearchData = useCallback((name: string, value: string) => {
+    setSearchData(searchData => ({ ...searchData, [name]: value }));
+  }, []);
+
+  useEffect(() => {
+    console.log(searchData);
+  }, [searchData]);
+
+  return (
+    <>
+      <Filter
+        name="region"
+        label="지역"
+        options={option_region}
+        onChange={handleSearchData}
+      />
+    </>
+  );
+}
+
+const option_status = [
+  { label: '전체', value: 'ALL' },
+  { label: '모집중', value: 'IN_PROGRESS' },
+  { label: '모집 종료', value: 'DONE' }
+];
+
+const option_region = [
+  { label: '내 주변', value: 'MY_REGION' },
+  { label: '서울', value: 'SEOUL' },
+  { label: '경기도', value: 'GYEONGGI' },
+  { label: '인천', value: 'INCHEON' },
+  { label: '대전', value: 'DAEJEON' },
+  { label: '강원도', value: 'GANGWON' },
+  { label: '대구', value: 'DAEGU' },
+  { label: '경상도', value: 'GYEONGSANG' },
+  { label: '충청도', value: 'CHUNGCHEONG' },
+  { label: '제주도', value: 'JEJU' }
+];

--- a/src/components/common/Skeleton/DeferredComponent.tsx
+++ b/src/components/common/Skeleton/DeferredComponent.tsx
@@ -11,7 +11,7 @@ const DeferredComponent = ({
   children
 }: PropsWithChildren<{ deferTime?: number }>) => {
   const [isDeferred, setIsDeferred] = useState(false);
-  const DEFERRED_MILLISEC = deferTime ? deferTime : 200;
+  const DEFERRED_MILLISEC = deferTime || 200;
 
   useEffect(() => {
     // DEFERRED_MILLISEC 지난 후 skeleton Render

--- a/src/components/common/Skeleton/DeferredComponent.tsx
+++ b/src/components/common/Skeleton/DeferredComponent.tsx
@@ -1,0 +1,31 @@
+import { PropsWithChildren, useEffect, useState } from 'react';
+
+/**
+ * Skeleton이 render 되는 시간을 조정할 수 있는
+ * DeferredComponent 입니다.
+ *
+ * @param {PropsWithChildren<{ deferTime: number }>} deferTime 지연 시간을 지정할 수 있습니다. (초기 값 200)
+ */
+const DeferredComponent = ({
+  deferTime,
+  children
+}: PropsWithChildren<{ deferTime?: number }>) => {
+  const [isDeferred, setIsDeferred] = useState(false);
+  const DEFERRED_MILLISEC = deferTime ? deferTime : 200;
+
+  useEffect(() => {
+    // DEFERRED_MILLISEC 지난 후 skeleton Render
+    const timeoutId = setTimeout(() => {
+      setIsDeferred(true);
+    }, DEFERRED_MILLISEC);
+    return () => clearTimeout(timeoutId);
+  }, [DEFERRED_MILLISEC]);
+
+  if (!isDeferred) {
+    return null;
+  }
+
+  return <>{children}</>;
+};
+
+export default DeferredComponent;

--- a/src/components/common/Skeleton/Skeleton.css.ts
+++ b/src/components/common/Skeleton/Skeleton.css.ts
@@ -1,0 +1,58 @@
+import { palette } from '@/styles/color';
+import { BREAK_POINT } from '@/styles/global.css';
+import { createVar, keyframes, style } from '@vanilla-extract/css';
+
+export const skeletonHeight = createVar('skeletonHeight');
+export const skeletonWidth = createVar('skeletonWidth');
+
+const loading = keyframes({
+  from: {
+    transform: 'translateX(0)'
+  },
+  to: {
+    transform: 'translateX(100%)'
+  }
+});
+
+export const wrapper = style({
+  padding: '16px',
+  background: palette.white,
+  borderRadius: '8px',
+  border: `1px solid ${palette.gray200}`,
+  cursor: 'pointer',
+  position: 'relative'
+});
+export const grid = style({
+  display: 'flex',
+  flexDirection: 'column',
+
+  gap: '10px'
+});
+export const inlineGrid = style({
+  display: 'flex',
+  flexDirection: 'row',
+  columnGap: '8px'
+});
+export const colGrid = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4px'
+});
+export const box = style({
+  width: skeletonWidth,
+  height: skeletonHeight,
+  borderRadius: '4px',
+  backgroundColor: 'rgba(0, 0, 0, 0.08)',
+  position: 'relative',
+  overflow: 'hidden',
+  '::before': {
+    content: '',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: BREAK_POINT,
+    height: '100%',
+    background: `linear-gradient(to right, #f2f2f2, #ddd, #f2f2f2)`,
+    animation: `${loading} 1s infinite linear`
+  }
+});

--- a/src/components/common/Skeleton/Skeleton.css.ts
+++ b/src/components/common/Skeleton/Skeleton.css.ts
@@ -1,6 +1,7 @@
 import { palette } from '@/styles/color';
 import { BREAK_POINT } from '@/styles/global.css';
 import { createVar, keyframes, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
 export const skeletonHeight = createVar('skeletonHeight');
 export const skeletonWidth = createVar('skeletonWidth');
@@ -22,37 +23,62 @@ export const wrapper = style({
   cursor: 'pointer',
   position: 'relative'
 });
-export const grid = style({
-  display: 'flex',
-  flexDirection: 'column',
-
-  gap: '10px'
-});
-export const inlineGrid = style({
-  display: 'flex',
-  flexDirection: 'row',
-  columnGap: '8px'
-});
-export const colGrid = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '4px'
-});
-export const box = style({
-  width: skeletonWidth,
-  height: skeletonHeight,
-  borderRadius: '4px',
-  backgroundColor: 'rgba(0, 0, 0, 0.08)',
-  position: 'relative',
-  overflow: 'hidden',
-  '::before': {
-    content: '',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: BREAK_POINT,
-    height: '100%',
-    background: `linear-gradient(to right, #f2f2f2, #ddd, #f2f2f2)`,
-    animation: `${loading} 1s infinite linear`
+export const grid = recipe({
+  base: { display: 'flex', flexDirection: 'column' },
+  variants: {
+    size: {
+      sm: {
+        gap: '4px'
+      },
+      md: {
+        gap: '10px'
+      }
+    }
   }
+});
+export const inlineGrid = recipe({
+  base: { display: 'flex', flexDirection: 'row' },
+  variants: {
+    size: {
+      sm: {
+        columnGap: '4px'
+      },
+      md: {
+        columnGap: '8px'
+      }
+    }
+  }
+});
+export const box = recipe({
+  base: {
+    width: skeletonWidth,
+    height: skeletonHeight,
+    borderRadius: '4px',
+    backgroundColor: 'rgba(0, 0, 0, 0.08)',
+    position: 'relative',
+    overflow: 'hidden',
+    '::before': {
+      content: '',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: BREAK_POINT,
+      height: '100%',
+      background: `linear-gradient(to right, #f2f2f2, #ddd, #f2f2f2)`,
+      animation: `${loading} 1s infinite linear`
+    }
+  },
+  variants: {
+    variant: {
+      square: {},
+      circle: {
+        borderRadius: '50%'
+      }
+    }
+  }
+});
+export const list = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px'
 });

--- a/src/components/common/Skeleton/Skeleton.tsx
+++ b/src/components/common/Skeleton/Skeleton.tsx
@@ -1,22 +1,24 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import * as styles from './Skeleton.css';
 
-interface SkeletonProps {}
+export interface SkeletonProps {
+  isShelter?: boolean;
+}
 
-export default function Skeleton({}: SkeletonProps) {
+export default function Skeleton({ isShelter = false }: SkeletonProps) {
   return (
     <main className={styles.wrapper}>
-      <article className={styles.grid}>
-        <section className={styles.inlineGrid}>
+      <article className={styles.grid({ size: 'md' })}>
+        <section className={styles.inlineGrid({ size: 'md' })}>
           <div
-            className={styles.box}
+            className={styles.box({ variant: 'square' })}
             style={assignInlineVars({
               [styles.skeletonWidth]: '52px',
               [styles.skeletonHeight]: '26px'
             })}
           ></div>
           <div
-            className={styles.box}
+            className={styles.box({ variant: 'square' })}
             style={assignInlineVars({
               [styles.skeletonWidth]: '69px',
               [styles.skeletonHeight]: '26px'
@@ -24,28 +26,46 @@ export default function Skeleton({}: SkeletonProps) {
           ></div>
         </section>
         <section
-          className={styles.box}
+          className={styles.box({ variant: 'square' })}
           style={assignInlineVars({
             [styles.skeletonWidth]: '100%',
             [styles.skeletonHeight]: '22px'
           })}
         ></section>
-        <section className={styles.colGrid}>
+        <section className={styles.grid({ size: 'sm' })}>
           <div
-            className={styles.box}
+            className={styles.box({ variant: 'square' })}
             style={assignInlineVars({
               [styles.skeletonWidth]: '180px',
               [styles.skeletonHeight]: '20px'
             })}
           ></div>
           <div
-            className={styles.box}
+            className={styles.box({ variant: 'square' })}
             style={assignInlineVars({
               [styles.skeletonWidth]: '60px',
               [styles.skeletonHeight]: '20px'
             })}
           ></div>
         </section>
+        {isShelter && (
+          <section className={styles.inlineGrid({ size: 'sm' })}>
+            <div
+              className={styles.box({ variant: 'circle' })}
+              style={assignInlineVars({
+                [styles.skeletonWidth]: '20px',
+                [styles.skeletonHeight]: '20px'
+              })}
+            ></div>
+            <div
+              className={styles.box({ variant: 'square' })}
+              style={assignInlineVars({
+                [styles.skeletonWidth]: '100px',
+                [styles.skeletonHeight]: '20px'
+              })}
+            ></div>
+          </section>
+        )}
       </article>
     </main>
   );

--- a/src/components/common/Skeleton/Skeleton.tsx
+++ b/src/components/common/Skeleton/Skeleton.tsx
@@ -1,69 +1,41 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import * as styles from './Skeleton.css';
-
 export interface SkeletonProps {
   isShelter?: boolean;
 }
-
 export default function Skeleton({ isShelter = false }: SkeletonProps) {
+  function createSkeleton(
+    variant: 'square' | 'circle',
+    width: string,
+    height: string
+  ) {
+    return (
+      <div
+        className={styles.box({ variant })}
+        style={assignInlineVars({
+          [styles.skeletonWidth]: width,
+          [styles.skeletonHeight]: height
+        })}
+      ></div>
+    );
+  }
+
   return (
     <main className={styles.wrapper}>
       <article className={styles.grid({ size: 'md' })}>
         <section className={styles.inlineGrid({ size: 'md' })}>
-          <div
-            className={styles.box({ variant: 'square' })}
-            style={assignInlineVars({
-              [styles.skeletonWidth]: '52px',
-              [styles.skeletonHeight]: '26px'
-            })}
-          ></div>
-          <div
-            className={styles.box({ variant: 'square' })}
-            style={assignInlineVars({
-              [styles.skeletonWidth]: '69px',
-              [styles.skeletonHeight]: '26px'
-            })}
-          ></div>
+          {createSkeleton('square', '52px', '26px')}
+          {createSkeleton('square', '69px', '26px')}
         </section>
-        <section
-          className={styles.box({ variant: 'square' })}
-          style={assignInlineVars({
-            [styles.skeletonWidth]: '100%',
-            [styles.skeletonHeight]: '22px'
-          })}
-        ></section>
+        {createSkeleton('square', '100%', '22px')}
         <section className={styles.grid({ size: 'sm' })}>
-          <div
-            className={styles.box({ variant: 'square' })}
-            style={assignInlineVars({
-              [styles.skeletonWidth]: '180px',
-              [styles.skeletonHeight]: '20px'
-            })}
-          ></div>
-          <div
-            className={styles.box({ variant: 'square' })}
-            style={assignInlineVars({
-              [styles.skeletonWidth]: '60px',
-              [styles.skeletonHeight]: '20px'
-            })}
-          ></div>
+          {createSkeleton('square', '180px', '20px')}
+          {createSkeleton('square', '60px', '20px')}
         </section>
         {isShelter && (
           <section className={styles.inlineGrid({ size: 'sm' })}>
-            <div
-              className={styles.box({ variant: 'circle' })}
-              style={assignInlineVars({
-                [styles.skeletonWidth]: '20px',
-                [styles.skeletonHeight]: '20px'
-              })}
-            ></div>
-            <div
-              className={styles.box({ variant: 'square' })}
-              style={assignInlineVars({
-                [styles.skeletonWidth]: '100px',
-                [styles.skeletonHeight]: '20px'
-              })}
-            ></div>
+            {createSkeleton('circle', '20px', '20px')}
+            {createSkeleton('square', '100px', '20px')}
           </section>
         )}
       </article>

--- a/src/components/common/Skeleton/Skeleton.tsx
+++ b/src/components/common/Skeleton/Skeleton.tsx
@@ -1,0 +1,52 @@
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import * as styles from './Skeleton.css';
+
+interface SkeletonProps {}
+
+export default function Skeleton({}: SkeletonProps) {
+  return (
+    <main className={styles.wrapper}>
+      <article className={styles.grid}>
+        <section className={styles.inlineGrid}>
+          <div
+            className={styles.box}
+            style={assignInlineVars({
+              [styles.skeletonWidth]: '52px',
+              [styles.skeletonHeight]: '26px'
+            })}
+          ></div>
+          <div
+            className={styles.box}
+            style={assignInlineVars({
+              [styles.skeletonWidth]: '69px',
+              [styles.skeletonHeight]: '26px'
+            })}
+          ></div>
+        </section>
+        <section
+          className={styles.box}
+          style={assignInlineVars({
+            [styles.skeletonWidth]: '100%',
+            [styles.skeletonHeight]: '22px'
+          })}
+        ></section>
+        <section className={styles.colGrid}>
+          <div
+            className={styles.box}
+            style={assignInlineVars({
+              [styles.skeletonWidth]: '180px',
+              [styles.skeletonHeight]: '20px'
+            })}
+          ></div>
+          <div
+            className={styles.box}
+            style={assignInlineVars({
+              [styles.skeletonWidth]: '60px',
+              [styles.skeletonHeight]: '20px'
+            })}
+          ></div>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/src/components/common/Skeleton/SkeletonList.tsx
+++ b/src/components/common/Skeleton/SkeletonList.tsx
@@ -12,6 +12,7 @@ import * as styles from './Skeleton.css';
 export default function SkeletonList({ isShelter }: SkeletonProps) {
   return (
     <div className={styles.list}>
+      <div style={{ padding: '2px' }}></div>
       <div
         className={styles.box({ variant: 'square' })}
         style={assignInlineVars({

--- a/src/components/common/Skeleton/SkeletonList.tsx
+++ b/src/components/common/Skeleton/SkeletonList.tsx
@@ -22,7 +22,7 @@ export default function SkeletonList({ isShelter }: SkeletonProps) {
         })}
       ></div>
       {[...Array(4)].map(_ => (
-        <Skeleton key={uuidv4()} isShelter={isShelter || false} />
+        <Skeleton key={uuidv4()} isShelter={isShelter ?? false} />
       ))}
     </div>
   );

--- a/src/components/common/Skeleton/SkeletonList.tsx
+++ b/src/components/common/Skeleton/SkeletonList.tsx
@@ -1,6 +1,7 @@
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import Skeleton, { SkeletonProps } from './Skeleton';
 import * as styles from './Skeleton.css';
+import uuidv4 from '@/utils/uuidv4';
 
 /**
  * Skeleton이 render 되는 시간을 조정하고 싶을 시
@@ -20,8 +21,8 @@ export default function SkeletonList({ isShelter }: SkeletonProps) {
           [styles.skeletonHeight]: '26px'
         })}
       ></div>
-      {[...Array(4)].map((_, index) => (
-        <Skeleton key={index} isShelter={isShelter ? true : false} />
+      {[...Array(4)].map(_ => (
+        <Skeleton key={uuidv4()} isShelter={isShelter || false} />
       ))}
     </div>
   );

--- a/src/components/common/Skeleton/SkeletonList.tsx
+++ b/src/components/common/Skeleton/SkeletonList.tsx
@@ -1,0 +1,27 @@
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import Skeleton, { SkeletonProps } from './Skeleton';
+import * as styles from './Skeleton.css';
+
+/**
+ * Skeleton이 render 되는 시간을 조정하고 싶을 시
+ * DeferredComponent로 감싸서 이용합니다.
+ *
+ * @param {SkeletonProps} isShelter 보호소 전용 스켈레톤을 렌더할 수 있습니다.
+ * @returns {JSX.Element} The SkeletonList element.
+ */
+export default function SkeletonList({ isShelter }: SkeletonProps) {
+  return (
+    <div className={styles.list}>
+      <div
+        className={styles.box({ variant: 'square' })}
+        style={assignInlineVars({
+          [styles.skeletonWidth]: '73px',
+          [styles.skeletonHeight]: '26px'
+        })}
+      ></div>
+      {[...Array(4)].map((_, index) => (
+        <Skeleton key={index} isShelter={isShelter ? true : false} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/global/Dialog/utils/motion.ts
+++ b/src/components/global/Dialog/utils/motion.ts
@@ -23,7 +23,7 @@ export const bottomVariants = {
     y: '0%',
     transition: {
       type: 'spring',
-      stiffness: 300,
+      stiffness: 250,
       damping: 30
     }
   },
@@ -32,7 +32,7 @@ export const bottomVariants = {
     y: '100%',
     transition: {
       type: 'spring',
-      stiffness: 300,
+      stiffness: 250,
       damping: 30
     }
   }

--- a/src/components/global/ScrollToTop/ScrollToTop.tsx
+++ b/src/components/global/ScrollToTop/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { PropsWithChildren, useEffect } from 'react';
+
+export default function ScrollToTop({ children }: PropsWithChildren) {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return <>{children}</>;
+}

--- a/src/components/volunteer-schedule/ScheduleTab/ScheduleTab.tsx
+++ b/src/components/volunteer-schedule/ScheduleTab/ScheduleTab.tsx
@@ -8,6 +8,7 @@ import useVolunteerEventList, {
 } from '@/api/shelter/volunteer-event/useVolunteerEventList';
 import { getStartOfMonth, getEndOfMonth } from '@/utils/timeConvert';
 import { HEADER_HEIGHT } from '@/components/common/Header/Header.css';
+import SkeletonList from '@/components/common/Skeleton/SkeletonList';
 
 interface ScheduleTabProps {
   shelterId: number;
@@ -93,6 +94,7 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ shelterId }) => {
         onChangeMonth={handleChangeMonth}
       />
       <div style={{ marginTop: '16px' }}>
+        {(query.isLoading || query.isFetching) && <SkeletonList />}
         {volunteerEvents && (
           <VolunteerEventList
             selectedDate={selectedDate}

--- a/src/providers/AuthContext.tsx
+++ b/src/providers/AuthContext.tsx
@@ -104,10 +104,11 @@ const AuthProvider = ({ children }: PropsWithChildren) => {
           dangle_role: decodedToken.role
         }));
       }
-    } else {
-      if (!protectedRoutes.some(route => pathname.includes(route)))
-        router.push('/');
     }
+    // else {
+    //   if (!protectedRoutes.some(route => pathname.includes(route)))
+    //     router.push('/');
+    // }
   }, [router, pathname]);
 
   const logout = useCallback(() => {

--- a/src/utils/uuidv4.ts
+++ b/src/utils/uuidv4.ts
@@ -1,0 +1,7 @@
+export default function uuidv4() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0,
+      v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}

--- a/src/utils/uuidv4.ts
+++ b/src/utils/uuidv4.ts
@@ -1,6 +1,12 @@
 export default function uuidv4() {
+  const getRandomValue = () => {
+    const array = new Uint8Array(1);
+    crypto.getRandomValues(array);
+    return array[0] % 16;
+  };
+
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r = (Math.random() * 16) | 0,
+    const r = getRandomValue(),
       v = c === 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);
   });


### PR DESCRIPTION
## 스크린샷

https://github.com/YAPP-Github/dangledangle-client/assets/107424974/6afc500f-f2d3-4c32-b954-d1acdc02704c

<br>

## Motivation

- [YW2-146](https://yapp22-web2.atlassian.net/jira/software/projects/YW2/boards/3/timeline?selectedIssue=YW2-146)

<br>

## To Reviewers

- 이벤트 목록에서 이벤트 상세 페이지로 이동할 때 스크롤 위치가 하단으로 고정되어 있어, ScrollToTop Provider를 추가하였습니다.
- Skeleton Component의 렌더 시간을 조정할 수 있는 `DeferredComponent` 추가하였습니다. 
(SceduleTab에는 추가하지 않는 것이 더 자연스러운 UX 같아 추가하지 않은 상태입니다.) [카카오페이 아티클](https://tech.kakaopay.com/post/skeleton-ui-idea/)
- 필터 Component 내부 바텀시트에 **fixed 속성**으로 인해 상위 태그에서 transform으로 마진 조정을 할 시 CSS가 깨지는 문제가 있습니다. **marginLeft로 조절**해주세요.

```
      <div
        style={{
          backgroundColor: palette.white,
          width: BREAK_POINT,
          padding: '20px'
          marginLeft: `-${GLOBAL_PADDING_X}px` ✅ good
          // transform: `translateX(-${GLOBAL_PADDING_X}px)` ❌ error
        }}
      >
        <FilterExample />
      </div>
```

### Key Changes

- Skeleton / Filter UI 추가
- BottomSheet height, motion 스타일 조정
