### PR TITLE
[Feat] 홈 캘린더 영역 이벤트 리스트 api

### DIFF
--- a/src/api/volunteer-event/index.ts
+++ b/src/api/volunteer-event/index.ts
@@ -1,0 +1,66 @@
+import {
+  RegionOptions,
+  VolunteerEventCategory
+} from '@/constants/volunteerEvent';
+import api from '../instance';
+import { EventStatus, HomeVolunteerEvent } from '@/types/volunteerEvent';
+
+export type HomeEventFilter = {
+  category?: 'all' | VolunteerEventCategory;
+  status?: 'all' | EventStatus;
+  longitude?: number;
+  latitude?: number;
+  address?: '내 주변' | RegionOptions;
+  isFavorite?: boolean;
+};
+
+export const queryKey = {
+  all: 'all-volunteer-event' as const,
+  list: (filter: Omit<HomeEventFilter, 'longitude' | 'latitude'>) => [
+    queryKey.all,
+    filter
+  ]
+};
+
+export type GetParams = {
+  from: string;
+  to: string;
+  category: VolunteerEventCategory | null;
+  status: EventStatus | null;
+  longitude: number | null;
+  latitude: number | null;
+  address: RegionOptions | null;
+  isFavorite: boolean | null;
+};
+
+export type GetResponse = {
+  events: HomeVolunteerEvent[];
+  from: string;
+  to: string;
+};
+
+export const get = async (
+  params: HomeEventFilter,
+  from: string,
+  to: string
+): Promise<GetResponse> => {
+  const payload: GetParams = {
+    category: params.category === 'all' ? null : params.category || null,
+    status: params.status === 'all' ? null : params.status || null,
+    from,
+    to,
+    longitude: params.longitude || null,
+    latitude: params.latitude || null,
+    address: params.address === '내 주변' ? null : params.address || null,
+    isFavorite: params.isFavorite || null
+  };
+
+  const data = await api
+    .post('volunteer-event', { json: payload })
+    .json<HomeVolunteerEvent[]>();
+  return {
+    events: data,
+    from,
+    to
+  };
+};

--- a/src/api/volunteer-event/useHomeEventList.ts
+++ b/src/api/volunteer-event/useHomeEventList.ts
@@ -1,0 +1,90 @@
+import {
+  UseInfiniteQueryOptions,
+  useInfiniteQuery
+} from '@tanstack/react-query';
+import { Moment } from 'moment';
+import moment from 'moment';
+import {
+  formatDatetimeForServer,
+  getEndOfMonth,
+  getStartOfMonth,
+  minutes
+} from '@/utils/timeConvert';
+import { NUM_OF_MAX_ITERATION_MONTHS } from '@/constants/volunteerEvent';
+import { GetResponse, HomeEventFilter, get, queryKey } from '.';
+
+export default function useHomeEventList(
+  filter: HomeEventFilter,
+  from: Moment,
+  to: Moment,
+  options?: UseInfiniteQueryOptions<GetResponse>
+) {
+  const filterForKey = {
+    ...filter
+  };
+  delete filterForKey.latitude;
+  delete filterForKey.longitude;
+  return useInfiniteQuery<GetResponse>(
+    queryKey.list(filterForKey),
+    ({
+      pageParam = {
+        from,
+        to
+      }
+    }) =>
+      get(
+        filter,
+        formatDatetimeForServer(pageParam.from, 'DATE'),
+        formatDatetimeForServer(pageParam.to, 'DATE')
+      ),
+    {
+      cacheTime: minutes(10),
+      ...options
+    }
+  );
+}
+
+export type UseVolunteerEventListPageParam = {
+  to: Moment;
+  from: Moment;
+};
+
+export const monthlyInfiniteOption: UseInfiniteQueryOptions<GetResponse> = {
+  getPreviousPageParam: (
+    lastPage
+  ): UseVolunteerEventListPageParam | undefined => {
+    const prevDate = moment(lastPage.from).subtract(1, 'month');
+
+    // NUM_OF_MAX_ITERATION_MONTHS개월 이전 데이터는 받아오지 않는다.
+    const minDate = getStartOfMonth(new Date()).subtract(
+      NUM_OF_MAX_ITERATION_MONTHS,
+      'months'
+    );
+    if (prevDate.isSameOrBefore(minDate)) {
+      return undefined;
+    }
+
+    return {
+      from: getStartOfMonth(prevDate),
+      to: getEndOfMonth(prevDate)
+    };
+  },
+  getNextPageParam: (lastPage): UseVolunteerEventListPageParam | undefined => {
+    const nextDate = moment(lastPage.from).add(1, 'month');
+
+    // NUM_OF_MAX_ITERATION_MONTHS개월 이후 데이터는 받아오지 않는다.
+    const maxDate = getStartOfMonth(new Date()).add(
+      NUM_OF_MAX_ITERATION_MONTHS,
+      'months'
+    );
+
+    if (nextDate.isSameOrAfter(maxDate)) {
+      return undefined;
+    }
+
+    return {
+      from: getStartOfMonth(nextDate),
+      to: getEndOfMonth(nextDate)
+    };
+  }
+};

--- a/src/asset/icons/Add.svg
+++ b/src/asset/icons/Add.svg
@@ -1,0 +1,6 @@
+<svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Iconly/Light-Outline/Document">
+<path id="Vector 29" d="M8.5 2V14" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+<path id="Vector 30" d="M2.5 8L14.5 8" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+</g>
+</svg>

--- a/src/asset/icons/index.ts
+++ b/src/asset/icons/index.ts
@@ -45,3 +45,4 @@ export { default as Register_1 } from './Register_1.svg';
 export { default as Register_2 } from './Register_2.svg';
 export { default as Register_3 } from './Register_3.svg';
 export { default as Register_4 } from './Register_4.svg';
+export { default as Add } from './Add.svg';

--- a/src/components/common/FixedFooter/FixedFooter.css.ts
+++ b/src/components/common/FixedFooter/FixedFooter.css.ts
@@ -4,6 +4,7 @@ import { createVar, style } from '@vanilla-extract/css';
 export const footerColor = createVar('footerColor');
 
 export const fixedFooter = style({
+  backgroundColor: 'unset',
   position: 'fixed',
   bottom: 0,
   right: 0,
@@ -14,6 +15,7 @@ export const fixedFooter = style({
 });
 
 export const wrapper = style({
+  boxSizing: 'border-box',
   maxWidth: `${BREAK_POINT}px`,
   width: '100%',
   padding: `10px ${GLOBAL_PADDING_X}px 30px`,

--- a/src/components/home/CalendarSection/CalendarSection.css.ts
+++ b/src/components/home/CalendarSection/CalendarSection.css.ts
@@ -1,6 +1,6 @@
 import { HEADER_HEIGHT } from '@/components/common/Header/Header.css';
 import { palette } from '@/styles/color';
-import { GLOBAL_PADDING_X, expandGlobalPadding } from '@/styles/global.css';
+import { expandGlobalPadding } from '@/styles/global.css';
 import { style } from '@vanilla-extract/css';
 
 export const FILTER_HEIGHT = 47.5;
@@ -14,7 +14,8 @@ export const expandWhiteContainer = style([
 
 export const sticky = style({
   position: 'sticky',
-  top: HEADER_HEIGHT
+  top: HEADER_HEIGHT,
+  zIndex: 10
 });
 export const filterContainer = style([
   expandWhiteContainer,

--- a/src/components/home/CalendarSection/CalendarSection.tsx
+++ b/src/components/home/CalendarSection/CalendarSection.tsx
@@ -24,6 +24,7 @@ import useHomeEventList, {
 import { HomeEventFilter } from '@/api/volunteer-event';
 import { getEndOfMonth, getStartOfMonth } from '@/utils/timeConvert';
 import SkeletonList from '@/components/common/Skeleton/SkeletonList';
+import { homeEventsMock } from './mock';
 
 export default function CalendarSection() {
   const { dangle_role } = useAuthContext();
@@ -62,10 +63,12 @@ export default function CalendarSection() {
     { ...monthlyInfiniteOption, enabled: !loading }
   );
 
-  const volunteerEvents = useMemo(() => {
-    const pages = query.data?.pages;
-    return pages?.flatMap(page => page.events);
-  }, [query.data?.pages]);
+  // const volunteerEvents = useMemo(() => {
+  //   const pages = query.data?.pages;
+  //   return pages?.flatMap(page => page.events);
+  // }, [query.data?.pages]);
+
+  const volunteerEvents = homeEventsMock;
 
   const handleChangeFilter = useCallback(
     (name: string, value: string | boolean) => {

--- a/src/components/home/CalendarSection/CalendarSection.tsx
+++ b/src/components/home/CalendarSection/CalendarSection.tsx
@@ -63,12 +63,14 @@ export default function CalendarSection() {
     { ...monthlyInfiniteOption, enabled: !loading }
   );
 
-  // const volunteerEvents = useMemo(() => {
-  //   const pages = query.data?.pages;
-  //   return pages?.flatMap(page => page.events);
-  // }, [query.data?.pages]);
-
-  const volunteerEvents = homeEventsMock;
+  const volunteerEvents = useMemo(() => {
+    // TODO: mock data 제거
+    if (!query.data) {
+      return homeEventsMock;
+    }
+    const pages = query.data?.pages;
+    return pages?.flatMap(page => page.events);
+  }, [query.data]);
 
   const handleChangeFilter = useCallback(
     (name: string, value: string | boolean) => {

--- a/src/components/home/CalendarSection/CalendarSection.tsx
+++ b/src/components/home/CalendarSection/CalendarSection.tsx
@@ -1,16 +1,15 @@
 'use client';
 
 import Filter, { FilterRef } from '@/components/common/Filter/Filter';
-import HomeCalendar from '@/components/home/HomeCalendar/HomeCalendar';
+import HomeCalendar, {
+  CALENDAR_ID
+} from '@/components/home/HomeCalendar/HomeCalendar';
 import {
   CATEGORY_OPTIONS,
   EVENT_STATUS_FILTER_OPTIONS,
-  REGION_OPTIONS,
-  RegionOptions,
-  VolunteerEventCategory
+  REGION_OPTIONS
 } from '@/constants/volunteerEvent';
-import { EventStatus } from '@/types/volunteerEvent';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as styles from './CalendarSection.css';
 import ChipInput from '@/components/common/ChipInput/ChipInput';
 import { Body3, H4 } from '@/components/common/Typography';
@@ -18,30 +17,59 @@ import { useAuthContext } from '@/providers/AuthContext';
 import getUserGeolocation from './utils/getUserGeolocation';
 import useBooleanState from '@/hooks/useBooleanState';
 import { HEADER_HEIGHT } from '@/components/common/Header/Header.css';
+import VolunteerEventList from '@/components/volunteer-schedule/VolunteerEventList/VolunteerEventList';
+import useHomeEventList, {
+  monthlyInfiniteOption
+} from '@/api/volunteer-event/useHomeEventList';
+import { HomeEventFilter } from '@/api/volunteer-event';
+import { getEndOfMonth, getStartOfMonth } from '@/utils/timeConvert';
+import SkeletonList from '@/components/common/Skeleton/SkeletonList';
 
-type EventFilter = {
-  region: '내 주변' | RegionOptions;
-  category: 'all' | VolunteerEventCategory;
-  status: EventStatus;
-  bookmark: boolean;
-};
 export default function CalendarSection() {
   const { dangle_role } = useAuthContext();
-  const [filter, setFilter] = useState<EventFilter>({
-    region: '내 주변',
+  const [filterInput, setFilterInput] = useState<HomeEventFilter>({
+    address: '내 주변',
     category: 'all',
-    status: 'IN_PROGRESS',
-    bookmark: false
+    status: dangle_role === 'SHELTER' ? 'IN_PROGRESS' : 'all',
+    isFavorite: false
   });
   const [loading, loadingOn, loadingOff] = useBooleanState(true);
   const [geolocation, setGeolocation] = useState<GeolocationPosition>();
   const regionFilterRef = useRef<FilterRef>(null);
   const stickyRef = useRef<HTMLDivElement>(null);
   const [isFolded, setIsFolded] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+
+  const filterForQuery = useMemo<HomeEventFilter>(() => {
+    if (
+      dangle_role !== 'SHELTER' &&
+      filterInput.address === '내 주변' &&
+      geolocation
+    ) {
+      return {
+        ...filterInput,
+        longitude: geolocation.coords.longitude,
+        latitude: geolocation.coords.latitude
+      };
+    }
+    return { ...filterInput, address: undefined };
+  }, [dangle_role, filterInput, geolocation]);
+
+  const query = useHomeEventList(
+    filterForQuery,
+    getStartOfMonth(new Date()),
+    getEndOfMonth(new Date()),
+    { ...monthlyInfiniteOption, enabled: !loading }
+  );
+
+  const volunteerEvents = useMemo(() => {
+    const pages = query.data?.pages;
+    return pages?.flatMap(page => page.events);
+  }, [query.data?.pages]);
 
   const handleChangeFilter = useCallback(
     (name: string, value: string | boolean) => {
-      setFilter(prev => ({
+      setFilterInput(prev => ({
         ...prev,
         [name]: value
       }));
@@ -50,19 +78,25 @@ export default function CalendarSection() {
   );
 
   useEffect(() => {
-    if (dangle_role !== 'SHELTER' && filter.region === '내 주변') {
+    if (dangle_role !== 'SHELTER' && filterInput.address === '내 주변') {
       loadingOn();
       getUserGeolocation()
         .then(setGeolocation)
         .catch(() => {
           regionFilterRef.current?.setPickOption(REGION_OPTIONS[0]);
-          setFilter(prev => ({ ...prev, region: REGION_OPTIONS[0] }));
+          setFilterInput(prev => ({ ...prev, address: REGION_OPTIONS[0] }));
         })
         .finally(loadingOff);
     } else {
       loadingOff();
     }
-  }, [dangle_role, filter.region, handleChangeFilter, loadingOff, loadingOn]);
+  }, [
+    dangle_role,
+    filterInput.address,
+    handleChangeFilter,
+    loadingOff,
+    loadingOn
+  ]);
 
   useEffect(() => {
     function autoFoldCalendar() {
@@ -79,6 +113,22 @@ export default function CalendarSection() {
       window.removeEventListener('scroll', autoFoldCalendar);
     };
   }, []);
+
+  const scrollToTarget = (eventCardEl: HTMLElement) => {
+    const calendarEl = document.getElementById(CALENDAR_ID);
+    if (!calendarEl) return;
+
+    const calendarBottom = calendarEl.getBoundingClientRect().bottom;
+    const eventCardTop = eventCardEl.getBoundingClientRect().top;
+    const scrollTo = window.scrollY + eventCardTop - calendarBottom;
+
+    window.scrollTo({ top: scrollTo, behavior: 'smooth' });
+  };
+
+  const fetchNextEvents = useCallback(async () => {
+    const result = await query.fetchNextPage();
+    return { hasNext: Boolean(result.hasNextPage) };
+  }, [query]);
 
   return (
     <div>
@@ -98,7 +148,7 @@ export default function CalendarSection() {
             <Filter
               ref={regionFilterRef}
               label="지역"
-              name="region"
+              name="address"
               options={['내 주변', ...REGION_OPTIONS]}
               onChange={handleChangeFilter}
             />
@@ -108,7 +158,7 @@ export default function CalendarSection() {
               flexWrap: 'nowrap'
             }}
             name="category"
-            value={filter.category}
+            value={filterInput.category || 'all'}
             options={[{ label: '전체', value: 'all' }, ...CATEGORY_OPTIONS]}
             onChange={handleChangeFilter}
           />
@@ -116,12 +166,14 @@ export default function CalendarSection() {
         <HomeCalendar
           isFolded={isFolded}
           setIsFolded={setIsFolded}
-          bookmark={filter.bookmark}
+          date={selectedDate}
+          onClickDate={setSelectedDate}
+          bookmark={filterInput.isFavorite || false}
           onChangeBookmark={() =>
-            handleChangeFilter('bookmark', !filter.bookmark)
+            handleChangeFilter('isFavorite', !filterInput.isFavorite)
           }
         />
-        {dangle_role === 'NONE' && filter.bookmark && (
+        {dangle_role === 'NONE' && filterInput.isFavorite && (
           <div className={styles.empty}>
             <Body3 color="gray400">
               보호소 즐겨찾기 기능을 사용하려면 <br />
@@ -130,16 +182,17 @@ export default function CalendarSection() {
           </div>
         )}
       </div>
-      {!loading && (
-        <div>
-          <div className={styles.dummyItem} />
-          <div className={styles.dummyItem} />
-          <div className={styles.dummyItem} />
-          <div className={styles.dummyItem} />
-          <div className={styles.dummyItem} />
-          <div className={styles.dummyItem} />
-        </div>
-      )}
+      <div style={{ marginTop: '16px' }}>
+        {!volunteerEvents && <SkeletonList />}
+        {volunteerEvents && (
+          <VolunteerEventList
+            selectedDate={selectedDate}
+            events={volunteerEvents}
+            scrollTo={scrollToTarget}
+            fetchNextEvents={fetchNextEvents}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/home/CalendarSection/mock.ts
+++ b/src/components/home/CalendarSection/mock.ts
@@ -1,0 +1,95 @@
+import { HomeVolunteerEvent } from '@/types/volunteerEvent';
+
+export const homeEventsMock: HomeVolunteerEvent[] = [
+  {
+    shelterId: 8,
+    shelterName: '하영보호소',
+    shelterProfileImageUrl: null,
+
+    eventStatus: 'DONE',
+    category: 'WALKING',
+    volunteerEventId: 11,
+    title: '한강 인근 댕댕이 산책 봉사자 모집합니다.',
+    recruitNum: 5,
+    joinNum: 5,
+    waitingNum: 2,
+    startAt: '2023-08-01T12:30:55.162Z',
+    endAt: '2023-08-01T13:30:55.162Z',
+    myParticipationStatus: 'NONE'
+  },
+  {
+    shelterId: 8,
+    shelterName: '하영보호소',
+    shelterProfileImageUrl: null,
+    eventStatus: 'DONE',
+    category: 'WALKING',
+    volunteerEventId: 12,
+    title: '태평역 인근 산책 봉사자 모집합니다.',
+    recruitNum: 5,
+    joinNum: 5,
+    waitingNum: 5,
+    startAt: '2023-08-01T19:00:55.162Z',
+    endAt: '2023-08-01T20:00:55.162Z',
+    myParticipationStatus: 'PARTICIPATING'
+  },
+  {
+    shelterId: 8,
+    shelterName: '하영보호소',
+    shelterProfileImageUrl: null,
+    eventStatus: 'IN_PROGRESS',
+    category: 'SHELTER_CLEANING',
+    volunteerEventId: 13,
+    title: '노원역 인근 견사 청소 봉사자 모집합니다.',
+    joinNum: 4,
+    recruitNum: 5,
+    waitingNum: 0,
+    startAt: '2023-08-09T12:30:55.162Z',
+    endAt: '2023-08-09T14:30:55.162Z',
+    myParticipationStatus: 'WAITING'
+  },
+  {
+    shelterId: 8,
+    shelterName: '하영보호소',
+    shelterProfileImageUrl: null,
+    eventStatus: 'IN_PROGRESS',
+    category: 'PROMOTION',
+    volunteerEventId: 14,
+    title: '홍보물 제작 봉사자 모집합니다.',
+    recruitNum: 6,
+    joinNum: 6,
+    waitingNum: 3,
+    startAt: '2023-08-09T10:00:55.162Z',
+    endAt: '2023-08-09T12:00:55.162Z',
+    myParticipationStatus: 'NONE'
+  },
+  {
+    shelterId: 8,
+    shelterName: '하영보호소',
+    shelterProfileImageUrl: null,
+    eventStatus: 'IN_PROGRESS',
+    category: 'PROMOTION',
+    volunteerEventId: 15,
+    title: '홍보물 제작 봉사자 모집합니다.',
+    recruitNum: 6,
+    joinNum: 6,
+    waitingNum: 3,
+    startAt: '2023-08-20T12:00:55.162Z',
+    endAt: '2023-08-20T13:00:55.162Z',
+    myParticipationStatus: 'NONE'
+  },
+  {
+    shelterId: 8,
+    shelterName: '하영보호소',
+    shelterProfileImageUrl: null,
+    eventStatus: 'IN_PROGRESS',
+    category: 'PROMOTION',
+    volunteerEventId: 16,
+    title: '홍보물 제작 봉사자 모집합니다.',
+    recruitNum: 6,
+    joinNum: 6,
+    waitingNum: 3,
+    startAt: '2023-08-29T12:00:55.162Z',
+    endAt: '2023-08-29T16:00:55.162Z',
+    myParticipationStatus: 'NONE'
+  }
+];

--- a/src/components/home/HomeCalendar/HomeCalendar.tsx
+++ b/src/components/home/HomeCalendar/HomeCalendar.tsx
@@ -27,25 +27,25 @@ const FoldToggle: React.FC<FoldToggleProps> = ({
   );
 };
 
+export const CALENDAR_ID = 'home-calendar';
 interface HomeCalendarProps {
   isFolded: boolean;
   setIsFolded: (isFolded: boolean) => void;
   bookmark: boolean;
+  date: Date;
+  onClickDate: (value: Date) => void;
   onChangeBookmark: () => void;
 }
 const HomeCalendar: React.FC<HomeCalendarProps> = ({
   isFolded,
   setIsFolded,
   bookmark,
+  date,
+  onClickDate,
   onChangeBookmark
 }) => {
   const { dangle_role } = useAuthContext();
-  const [date, setDate] = useState(new Date());
   const [hasFolded, setHasFolded] = useState(false);
-
-  const handleChangeDate = useCallback((value: Date) => {
-    setDate(value);
-  }, []);
 
   useEffect(() => {
     if (isFolded && !hasFolded) {
@@ -69,8 +69,8 @@ const HomeCalendar: React.FC<HomeCalendarProps> = ({
           <DangleCalendar
             id="home-calendar"
             value={date}
-            onChange={handleChangeDate}
-            onChangeMonth={handleChangeDate}
+            onChange={onClickDate}
+            onChangeMonth={onClickDate}
           />
           <div className={styles.calendarFooter}>
             <div className={styles.toggleItem} onClick={onChangeBookmark}>

--- a/src/components/volunteer-schedule/FloatingButton/FloatingButton.css.ts
+++ b/src/components/volunteer-schedule/FloatingButton/FloatingButton.css.ts
@@ -1,0 +1,30 @@
+import { palette } from '@/styles/color';
+import { style } from '@vanilla-extract/css';
+
+export const floatingButton = style({
+  position: 'fixed',
+  bottom: 32,
+  zIndex: 1000,
+  margin: '0 auto',
+  left: 0,
+  right: 0,
+  width: 'fit-content',
+
+  cursor: 'pointer',
+  borderRadius: 100,
+  background: palette.primary300,
+  boxShadow: '0px 1px 5px 1px rgba(0, 0, 0, 0.15)',
+  padding: '12px 16px 12px 18px'
+});
+
+export const inner = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center'
+});
+
+export const prefixIcon = style({
+  width: 16,
+  height: 16,
+  marginRight: 4
+});

--- a/src/components/volunteer-schedule/FloatingButton/FloatingButton.tsx
+++ b/src/components/volunteer-schedule/FloatingButton/FloatingButton.tsx
@@ -1,0 +1,26 @@
+import { ButtonText1 } from '@/components/common/Typography';
+import * as styles from './FloatingButton.css';
+import { Add } from '@/asset/icons';
+import { PropsWithChildren } from 'react';
+
+interface FloatingButtonProps extends PropsWithChildren {
+  onClick?: () => void;
+}
+
+const FloatingButton: React.FC<FloatingButtonProps> = ({
+  children,
+  onClick
+}) => {
+  return (
+    <div className={styles.floatingButton} onClick={onClick}>
+      <div className={styles.inner}>
+        <div className={styles.prefixIcon}>
+          <Add />
+        </div>
+        <ButtonText1 color="white">{children}</ButtonText1>
+      </div>
+    </div>
+  );
+};
+
+export default FloatingButton;

--- a/src/components/volunteer-schedule/ScheduleTab/ScheduleTab.tsx
+++ b/src/components/volunteer-schedule/ScheduleTab/ScheduleTab.tsx
@@ -9,6 +9,9 @@ import useVolunteerEventList, {
 import { getStartOfMonth, getEndOfMonth } from '@/utils/timeConvert';
 import { HEADER_HEIGHT } from '@/components/common/Header/Header.css';
 import SkeletonList from '@/components/common/Skeleton/SkeletonList';
+import FloatingButton from '../FloatingButton/FloatingButton';
+import { useAuthContext } from '@/providers/AuthContext';
+import { useRouter } from 'next/navigation';
 
 interface ScheduleTabProps {
   shelterId: number;
@@ -16,7 +19,10 @@ interface ScheduleTabProps {
 
 export const CALENDAR_ID = 'schedule-tab-calendar';
 const ScheduleTab: React.FC<ScheduleTabProps> = ({ shelterId }) => {
+  const router = useRouter();
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const { dangle_id } = useAuthContext();
+
   const query = useVolunteerEventList(
     shelterId,
     getStartOfMonth(new Date()),
@@ -104,6 +110,13 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ shelterId }) => {
           />
         )}
       </div>
+      {dangle_id === shelterId && (
+        <FloatingButton
+          onClick={() => router.push('/admin/shelter/event/edit')}
+        >
+          일정 만들기
+        </FloatingButton>
+      )}
     </div>
   );
 };

--- a/src/components/volunteer-schedule/ScheduleTab/ScheduleTab.tsx
+++ b/src/components/volunteer-schedule/ScheduleTab/ScheduleTab.tsx
@@ -94,12 +94,11 @@ const ScheduleTab: React.FC<ScheduleTabProps> = ({ shelterId }) => {
         onChangeMonth={handleChangeMonth}
       />
       <div style={{ marginTop: '16px' }}>
-        {(query.isLoading || query.isFetching) && <SkeletonList />}
+        {!volunteerEvents && <SkeletonList />}
         {volunteerEvents && (
           <VolunteerEventList
             selectedDate={selectedDate}
             events={volunteerEvents}
-            shelterId={shelterId}
             scrollTo={scrollToTarget}
             fetchNextEvents={fetchNextEvents}
           />

--- a/src/components/volunteer-schedule/VolunteerEventCard/VolunteerEventCard.css.ts
+++ b/src/components/volunteer-schedule/VolunteerEventCard/VolunteerEventCard.css.ts
@@ -53,8 +53,19 @@ export const infoWrapper = style({
   columnGap: '6px'
 });
 
-export const status = style({
+export const statusWrapper = style({
   display: 'flex',
-  justifyContent: 'flex-end',
-  marginTop: '4px'
+  alignItems: 'flex-end'
+});
+
+export const myStatus = style({
+  textAlign: 'right',
+  flexGrow: 1,
+  marginTop: 4
+});
+
+export const shelterInfo = style({
+  display: 'flex',
+  marginTop: 10,
+  columnGap: 4
 });

--- a/src/components/volunteer-schedule/VolunteerEventCard/VolunteerEventCard.tsx
+++ b/src/components/volunteer-schedule/VolunteerEventCard/VolunteerEventCard.tsx
@@ -1,16 +1,20 @@
 import { Clock, Profile } from '@/asset/icons';
 import Badge from '@/components/common/Badge/Badge';
-import { Caption1, H4 } from '@/components/common/Typography';
+import { Caption1, Caption2, H4 } from '@/components/common/Typography';
 import { getDuration, isDatePast, pmamConvert } from '@/utils/timeConvert';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import * as styles from './VolunteerEventCard.css';
 import { CSSProperties } from 'react';
-import { VolunteerEvent } from '../../../types/volunteerEvent';
+import {
+  HomeVolunteerEvent,
+  VolunteerEvent
+} from '../../../types/volunteerEvent';
 import { VOLUNTEER_EVENT_CATEGORY } from '@/constants/volunteerEvent';
+import Avartar from '@/components/common/Avartar/Avartar';
 
 interface VolunteerEventCardProps {
-  event?: VolunteerEvent;
+  event?: VolunteerEvent | HomeVolunteerEvent;
   style?: CSSProperties;
 }
 
@@ -18,8 +22,10 @@ export default function VolunteerEventCard({
   event,
   style
 }: VolunteerEventCardProps) {
-  const pathname = usePathname();
+  const params = useParams();
   if (!event) return null;
+
+  const shelterId = 'shelterId' in event ? event.shelterId : params.id;
 
   const {
     eventStatus,
@@ -42,7 +48,7 @@ export default function VolunteerEventCard({
         })}
         style={style}
       >
-        <Link href={`${pathname}/event/${volunteerEventId}`}>
+        <Link href={`/shelter/${shelterId}/event/${volunteerEventId}`}>
           <div className={styles.container}>
             <div className={styles.badgeWrapper}>
               {isDatePast(startAt) ? (
@@ -76,11 +82,26 @@ export default function VolunteerEventCard({
                 </Caption1>
               </div>
 
-              <div className={styles.status}>
+              <div className={styles.statusWrapper}>
+                {'shelterId' in event && (
+                  <div className={styles.shelterInfo}>
+                    <Avartar
+                      size="20"
+                      shape="circle"
+                      defaultImage="shelter"
+                      imagePath={event.shelterProfileImageUrl}
+                    />
+                    <Caption2>{event.shelterName}</Caption2>
+                  </div>
+                )}
                 {myParticipationStatus === 'PARTICIPATING' ? (
-                  <Caption1 color="error">신청 완료</Caption1>
+                  <Caption1 color="error" className={styles.myStatus}>
+                    신청 완료
+                  </Caption1>
                 ) : myParticipationStatus === 'WAITING' ? (
-                  <Caption1 color="gray600">신청 대기중</Caption1>
+                  <Caption1 color="gray600" className={styles.myStatus}>
+                    신청 대기중
+                  </Caption1>
                 ) : null}
               </div>
             </div>

--- a/src/components/volunteer-schedule/VolunteerEventList/VolunteerEventList.tsx
+++ b/src/components/volunteer-schedule/VolunteerEventList/VolunteerEventList.tsx
@@ -1,5 +1,8 @@
 import VolunteerEventCard from '@/components/volunteer-schedule/VolunteerEventCard/VolunteerEventCard';
-import { VolunteerEvent } from '../../../types/volunteerEvent';
+import {
+  HomeVolunteerEvent,
+  VolunteerEvent
+} from '../../../types/volunteerEvent';
 import { H3 } from '../../common/Typography';
 import { formatDate, isDateSame } from '@/utils/timeConvert';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -9,7 +12,7 @@ import moment from 'moment';
 import { palette } from '@/styles/color';
 
 interface VolunteerEventListProps {
-  events: VolunteerEvent[];
+  events: VolunteerEvent[] | HomeVolunteerEvent[];
   selectedDate: Date;
   scrollTo: (eventCardEl: HTMLElement) => void;
   fetchNextEvents: () => Promise<{ hasNext: boolean }>;

--- a/src/components/volunteer-schedule/VolunteerEventList/VolunteerEventList.tsx
+++ b/src/components/volunteer-schedule/VolunteerEventList/VolunteerEventList.tsx
@@ -5,15 +5,12 @@ import { formatDate, isDateSame } from '@/utils/timeConvert';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Divider from '../../common/Divider/Divider';
 import useObserver from '@/hooks/useObserver';
-import { useIsFetching } from '@tanstack/react-query';
-import { queryKey } from '@/api/shelter/volunteer-event';
 import moment from 'moment';
 import { palette } from '@/styles/color';
 
 interface VolunteerEventListProps {
   events: VolunteerEvent[];
   selectedDate: Date;
-  shelterId: number;
   scrollTo: (eventCardEl: HTMLElement) => void;
   fetchNextEvents: () => Promise<{ hasNext: boolean }>;
 }
@@ -38,15 +35,11 @@ const DateHeader = ({
 const VolunteerEventList: React.FC<VolunteerEventListProps> = ({
   events,
   selectedDate,
-  shelterId,
   scrollTo,
   fetchNextEvents
 }) => {
   const [prevSelectedDate, setPrevSelectedDate] = useState(selectedDate);
   const { observe } = useObserver('observer-target');
-  const isFetchingEvents = useIsFetching({
-    queryKey: queryKey.list(shelterId)
-  });
 
   const handleIntersect = useCallback(async () => {
     const result = await fetchNextEvents();
@@ -75,7 +68,7 @@ const VolunteerEventList: React.FC<VolunteerEventListProps> = ({
   );
 
   useEffect(() => {
-    if (prevSelectedDate !== selectedDate && !isFetchingEvents) {
+    if (prevSelectedDate !== selectedDate) {
       const nearestDate = findNearestDate(selectedDate);
       const dateHeaderEl = document.getElementById(
         getDateHeaderElementId(nearestDate)
@@ -86,13 +79,7 @@ const VolunteerEventList: React.FC<VolunteerEventListProps> = ({
       if (!dateHeaderEl || !dateHeaderEl.parentElement) return;
       scrollTo(dateHeaderEl.parentElement);
     }
-  }, [
-    findNearestDate,
-    isFetchingEvents,
-    prevSelectedDate,
-    scrollTo,
-    selectedDate
-  ]);
+  }, [findNearestDate, prevSelectedDate, scrollTo, selectedDate]);
 
   return (
     <div>

--- a/src/types/volunteerEvent.ts
+++ b/src/types/volunteerEvent.ts
@@ -19,7 +19,7 @@ export interface VolunteerEvent {
 
 export interface VolunteerEventDetail extends VolunteerEvent {
   shelterName: string;
-  shelterProfileImageUrl: string;
+  shelterProfileImageUrl: string | null;
   title: string;
   description: string;
   address: ShelterAddress;
@@ -34,5 +34,5 @@ export interface VolunteerEventDetail extends VolunteerEvent {
 export interface HomeVolunteerEvent extends VolunteerEvent {
   shelterId: number;
   shelterName: string;
-  shelterProfileImageUrl: string;
+  shelterProfileImageUrl: string | null;
 }

--- a/src/types/volunteerEvent.ts
+++ b/src/types/volunteerEvent.ts
@@ -30,3 +30,9 @@ export interface VolunteerEventDetail extends VolunteerEvent {
   eventStatus: EventStatus;
   myParticipationStatus: MyParticipationStatus;
 }
+
+export interface HomeVolunteerEvent extends VolunteerEvent {
+  shelterId: number;
+  shelterName: string;
+  shelterProfileImageUrl: string;
+}


### PR DESCRIPTION
## 스크린샷

- 작업한 내용을 알기쉽게 스크린샷을 첨부해주세요!

<br>

## Motivation

- [YW2-159](https://yapp22-web2.atlassian.net/browse/YW2-159)
- api 연동

<br>

## To Reviewers

- 백엔드 쪽 오류로 mock data를 넣어놨습니다
- 캘린더에서 특정 날짜 클릭 시 가장 가까운 이벤트 카드로 스크롤하는 기능은 미완성입니다 (스크롤 위치 조정 필요)
- 보호소 홈에서 사용한 VolunteerEventList, VolunteerEventCard를 재사용했습니다 (추후 중복 코드를 더 제거하는 리팩토링 필요)


### Key Changes
- useHomeEventList 쿼리훅
- 일정만들기 FloatingButton 컴포넌트
