### PR TITLE
[Feat] 서버사이드에서도 유저 auth token 사용할 수 있도록 구현

### DIFF
--- a/src/api/auth/volunteer/refresh.ts
+++ b/src/api/auth/volunteer/refresh.ts
@@ -1,17 +1,31 @@
 import api from '@/api/instance';
+import ky from 'ky';
 
 export type LoginResponse = {
   accessToken: string;
   refreshToken: string;
 };
-type LoginPayload = LoginResponse;
+export type LoginPayload = LoginResponse;
 
-export const fetchRefresh = async (data: LoginPayload) => {
+export const fetchRefresh = async (data: LoginResponse) => {
   const response = await api
     .post(`auth/token/refresh`, {
       json: data
     })
     .then(res => res.json<LoginResponse>());
+  return response;
+};
+
+export const getRefresh = async () => {
+  const response = await ky
+    .get(`auth/token/refresh`, {
+      prefixUrl: process.env.NEXT_PUBLIC_FRONT_ENDPOINT
+    })
+    .then(res =>
+      res.json<{
+        success: boolean;
+      }>()
+    );
 
   return response;
 };

--- a/src/api/auth/volunteer/refresh.ts
+++ b/src/api/auth/volunteer/refresh.ts
@@ -1,5 +1,4 @@
-import api from '@/api/instance';
-import ky from 'ky';
+import api, { fe } from '@/api/instance';
 
 export type LoginResponse = {
   accessToken: string;
@@ -17,15 +16,11 @@ export const fetchRefresh = async (data: LoginResponse) => {
 };
 
 export const getRefresh = async () => {
-  const response = await ky
-    .get(`auth/token/refresh`, {
-      prefixUrl: process.env.NEXT_PUBLIC_FRONT_ENDPOINT
-    })
-    .then(res =>
-      res.json<{
-        success: boolean;
-      }>()
-    );
+  const response = await fe.get(`auth/token/refresh`).then(res =>
+    res.json<{
+      success: boolean;
+    }>()
+  );
 
   return response;
 };

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -6,7 +6,17 @@ import {
   throwServerErrorMessage
 } from '@/utils/ky/hooks/afterResponse';
 
-const api = ky.create({
+/**
+ * cookie에 있는 authroitoken 저장하는 공간,
+ * beforeRequest 훅에서 여기 있는 store를 꺼내서 헤더에 넣어준다.
+ */
+export const store: { [key in string]: string } = {};
+
+export const setStore = (key: string, value: string) => {
+  store[key] = value;
+};
+
+const api = ky.extend({
   prefixUrl: process.env.NEXT_PUBLIC_API_ENDPOINT,
   headers: {
     'Content-Type': 'application/json'

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -7,7 +7,7 @@ import {
 } from '@/utils/ky/hooks/afterResponse';
 
 /**
- * cookie에 있는 authroitoken 저장하는 공간,
+ * client 사이드에서 httponly 쿠키 사용이 불가능하므로 객체에 저장
  * beforeRequest 훅에서 여기 있는 store를 꺼내서 헤더에 넣어준다.
  */
 export const store: { [key in string]: string } = {};
@@ -15,6 +15,7 @@ export const store: { [key in string]: string } = {};
 export const setStore = (key: string, value: string) => {
   store[key] = value;
 };
+export const removeStore = (key: string) => {};
 
 const api = ky.extend({
   prefixUrl: process.env.NEXT_PUBLIC_API_ENDPOINT,

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -25,7 +25,7 @@ const api = ky.extend({
   hooks: {
     beforeRequest: [setAuthorizationHeader(process)],
     afterResponse: [
-      retryRequestOnUnauthorized,
+      retryRequestOnUnauthorized(process),
       throwServerErrorMessage,
       deleteClientCokiesPath
     ]

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -32,4 +32,8 @@ const api = ky.extend({
   }
 });
 
+export const fe = ky.extend({
+  prefixUrl: process.env.NEXT_PUBLIC_FRONT_ENDPOINT
+});
+
 export default api;

--- a/src/api/mypage/event/event.ts
+++ b/src/api/mypage/event/event.ts
@@ -6,10 +6,10 @@ export const queryKey = {
   all: ['mypage-event'] as const
 };
 
-export interface MypageEvent {
+export interface MypageEvent<T extends MyShelterEvent | MyVolunteerEvent> {
   pageNumber: number;
   pageSize: number;
-  content: MyShelterEvent[] | MyVolunteerEvent[];
+  content: T[];
 }
 
 export interface MyBaseEvent {
@@ -43,7 +43,7 @@ export const getMyShelterEvent = async (filter: MypageEventParams) => {
 
   const response = await api
     .get(`shelter/admin/my/volunteer-event${queryParameters}`)
-    .then(res => res.json<MypageEvent>());
+    .then(res => res.json<MypageEvent<MyShelterEvent>>());
   return response;
 };
 
@@ -52,6 +52,6 @@ export const getMyVolEvent = async (filter: MypageEventParams) => {
 
   const response = await api
     .get(`volunteer/my/volunteer-event${queryParameters}`)
-    .then(res => res.json<MypageEvent>());
+    .then(res => res.json<MypageEvent<MyVolunteerEvent>>());
   return response;
 };

--- a/src/api/mypage/event/useMyShelterEvent.tsx
+++ b/src/api/mypage/event/useMyShelterEvent.tsx
@@ -3,6 +3,7 @@ import {
   useInfiniteQuery
 } from '@tanstack/react-query';
 import {
+  MyShelterEvent,
   MypageEvent,
   MypageEventParams,
   getMyShelterEvent,
@@ -11,9 +12,9 @@ import {
 
 export default function useMyShelterEvent(
   filter?: MypageEventParams,
-  options?: UseInfiniteQueryOptions<MypageEvent>
+  options?: UseInfiniteQueryOptions<MypageEvent<MyShelterEvent>>
 ) {
-  return useInfiniteQuery<MypageEvent>(
+  return useInfiniteQuery<MypageEvent<MyShelterEvent>>(
     [...queryKey.all, JSON.stringify(filter)],
     ({ pageParam = 0 }) => getMyShelterEvent({ ...filter, page: pageParam }),
     {

--- a/src/api/mypage/event/useMyVolEvent.tsx
+++ b/src/api/mypage/event/useMyVolEvent.tsx
@@ -3,6 +3,7 @@ import {
   useInfiniteQuery
 } from '@tanstack/react-query';
 import {
+  MyVolunteerEvent,
   MypageEvent,
   MypageEventParams,
   getMyVolEvent,
@@ -11,9 +12,9 @@ import {
 
 export default function useMyVolEvent(
   filter?: MypageEventParams,
-  options?: UseInfiniteQueryOptions<MypageEvent>
+  options?: UseInfiniteQueryOptions<MypageEvent<MyVolunteerEvent>>
 ) {
-  return useInfiniteQuery<MypageEvent>(
+  return useInfiniteQuery<MypageEvent<MyVolunteerEvent>>(
     [...queryKey.all, JSON.stringify(filter)],
     ({ pageParam = 0 }) => getMyVolEvent({ ...filter, page: pageParam }),
     {

--- a/src/api/mypage/mypage.ts
+++ b/src/api/mypage/mypage.ts
@@ -1,3 +1,4 @@
+import { Options } from 'ky';
 import api from '../instance';
 
 export const queryKey = {
@@ -58,8 +59,10 @@ export const getShelterInfo = async () => {
   return response;
 };
 
-export const logout = async () => {
-  const response = await api.get(`auth/logout`).then(res => res.json<string>());
+export const logout = async (options?: Options) => {
+  const response = await api
+    .get(`auth/logout`, options)
+    .then(res => res.json<string>());
   return response;
 };
 

--- a/src/api/mypage/useLogout.tsx
+++ b/src/api/mypage/useLogout.tsx
@@ -1,32 +1,26 @@
-import { initialAuthState, useAuthContext } from '@/providers/AuthContext';
+import { useAuthContext } from '@/providers/AuthContext';
 import { useMutation } from '@tanstack/react-query';
-import { logout } from './mypage';
-import Cookies from 'js-cookie';
-import {
-  COOKIE_ACCESS_TOKEN_KEY,
-  COOKIE_REFRESH_TOKEN_KEY
-} from '@/constants/cookieKeys';
-import { useRouter } from 'next/navigation';
 import useToast from '@/hooks/useToast';
+import ky from 'ky';
 
 export default function useLogout() {
-  const { setAuthState } = useAuthContext();
-  const router = useRouter();
+  const { logout: clientLogout } = useAuthContext();
   const toastOn = useToast();
 
-  return useMutation<string, Error>(logout, {
-    onSuccess: response => {
-      if (Cookies.get(COOKIE_ACCESS_TOKEN_KEY)) {
-        setAuthState(initialAuthState); // AuthContext info delete
-        // client cookies delete
-        Cookies.remove(COOKIE_ACCESS_TOKEN_KEY);
-        Cookies.remove(COOKIE_REFRESH_TOKEN_KEY);
+  const logoutAPI = async () => {
+    const response = await ky
+      .get('auth/logout', {
+        prefixUrl: process?.env.NEXT_PUBLIC_FRONT_ENDPOINT
+      })
+      .then(res => res.json<string>());
+    return response;
+  };
 
-        router.push('/login');
-        toastOn('로그아웃이 완료되었습니다.');
-      } else {
-        console.error(response);
-      }
+  return useMutation<string, Error>(logoutAPI, {
+    onSuccess: response => {
+      clientLogout();
+      location.href = '/login';
+      toastOn('로그아웃이 완료되었습니다.');
     },
     onError: error => {
       console.error('Logout error:', error);

--- a/src/api/mypage/useLogout.tsx
+++ b/src/api/mypage/useLogout.tsx
@@ -1,17 +1,15 @@
 import { useAuthContext } from '@/providers/AuthContext';
 import { useMutation } from '@tanstack/react-query';
 import useToast from '@/hooks/useToast';
-import ky from 'ky';
+import { fe } from '../instance';
 
 export default function useLogout() {
   const { logout: clientLogout } = useAuthContext();
   const toastOn = useToast();
 
   const logoutAPI = async () => {
-    const response = await ky
-      .get('auth/logout', {
-        prefixUrl: process?.env.NEXT_PUBLIC_FRONT_ENDPOINT
-      })
+    const response = await fe
+      .get('auth/logout')
       .then(res => res.json<string>());
     return response;
   };

--- a/src/api/mypage/useMyInfo.tsx
+++ b/src/api/mypage/useMyInfo.tsx
@@ -12,7 +12,6 @@ export default function useMyInfo(
   options?: UseQueryOptions<MyVolInfo | MyShelterInfo>
 ) {
   const fetchData = async () => {
-    console.log(role);
     if (role === 'SHELTER') {
       return await getShelterInfo();
     } else {
@@ -21,6 +20,9 @@ export default function useMyInfo(
   };
 
   return useQuery<MyVolInfo | MyShelterInfo>(queryKey.all, fetchData, {
-    ...options
+    ...options,
+    onError(err) {
+      console.log(err);
+    }
   });
 }

--- a/src/api/shelter/auth/login.ts
+++ b/src/api/shelter/auth/login.ts
@@ -6,12 +6,10 @@ export interface LoginPayload {
   password: string;
 }
 
-export type LoginResponse =
-  | {
-      accessToken: string;
-      refreshToken: string;
-    }
-  | ApiErrorResponse;
+export type LoginResponse = {
+  accessToken: string;
+  refreshToken: string;
+};
 
 export const loginShelter = async (data: LoginPayload) => {
   const response = await api

--- a/src/api/shelter/auth/useShelterLogin.ts
+++ b/src/api/shelter/auth/useShelterLogin.ts
@@ -1,26 +1,35 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { LoginPayload, LoginResponse, loginShelter } from './login';
-import Cookies from 'js-cookie';
-import {
-  COOKIE_ACCESS_TOKEN_KEY,
-  COOKIE_REFRESH_TOKEN_KEY
-} from '@/constants/cookieKeys';
+import { LoginPayload } from './login';
+import ky from 'ky';
+import { ApiErrorResponse } from '@/types/apiTypes';
 
 export const shelterAuthKey = {
   all: ['shelterAuth'] as const
 };
 
+export type ShelterLoginResponse = {
+  redirect: string;
+};
+
+const shelterLoginAPI = async (data: LoginPayload) => {
+  const response = await ky
+    .post(`auth/shelter/login`, {
+      json: data,
+      prefixUrl: process.env.NEXT_PUBLIC_FRONT_ENDPOINT
+    })
+    .then(res => res.json<ShelterLoginResponse>());
+
+  return response;
+};
+
 export default function useShelterLogin() {
   const queryClient = useQueryClient();
-  return useMutation<LoginResponse, Error, LoginPayload>(loginShelter, {
-    onSuccess: response => {
-      if ('accessToken' in response) {
-        Cookies.set(COOKIE_ACCESS_TOKEN_KEY, response.accessToken);
-        Cookies.set(COOKIE_REFRESH_TOKEN_KEY, response.refreshToken);
-        return queryClient.invalidateQueries(shelterAuthKey.all);
-      } else {
-        console.error(response);
+  return useMutation<ShelterLoginResponse, ApiErrorResponse, LoginPayload>(
+    shelterLoginAPI,
+    {
+      onSuccess: response => {
+        queryClient.invalidateQueries(shelterAuthKey.all);
       }
     }
-  });
+  );
 }

--- a/src/api/shelter/auth/useShelterLogin.ts
+++ b/src/api/shelter/auth/useShelterLogin.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { LoginPayload } from './login';
-import ky from 'ky';
 import { ApiErrorResponse } from '@/types/apiTypes';
+import { fe } from '@/api/instance';
 
 export const shelterAuthKey = {
   all: ['shelterAuth'] as const
@@ -12,10 +12,9 @@ export type ShelterLoginResponse = {
 };
 
 const shelterLoginAPI = async (data: LoginPayload) => {
-  const response = await ky
+  const response = await fe
     .post(`auth/shelter/login`, {
-      json: data,
-      prefixUrl: process.env.NEXT_PUBLIC_FRONT_ENDPOINT
+      json: data
     })
     .then(res => res.json<ShelterLoginResponse>());
 

--- a/src/api/volunteer/my/index.ts
+++ b/src/api/volunteer/my/index.ts
@@ -1,4 +1,5 @@
 import api from '@/api/instance';
+import { Options } from 'ky';
 
 export interface VolunteerMyResponse {
   nickName: string;
@@ -11,6 +12,6 @@ export interface VolunteerMyResponse {
   alarm: boolean;
 }
 
-export const get = async () => {
-  return await api.get('volunteer/my').json<VolunteerMyResponse>();
+export const get = async (option: Options) => {
+  return await api.get('volunteer/my', option).json<VolunteerMyResponse>();
 };

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,39 @@
+import { logout } from '@/api/mypage/mypage';
+import {
+  COOKIE_ACCESS_TOKEN_KEY,
+  COOKIE_REFRESH_TOKEN_KEY
+} from '@/constants/cookieKeys';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  console.log('logout');
+  const cookies = req.cookies;
+  const redirectPath = cookies.get('redirectUrl')?.value || '/';
+  const redirectTo = `${req.nextUrl.origin}${decodeURIComponent(redirectPath)}`;
+  const accessToken = cookies.get(COOKIE_ACCESS_TOKEN_KEY)?.value;
+
+  try {
+    if (!accessToken) throw new Error('accessToken is not exist');
+    await logout({
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    });
+
+    const res = NextResponse.json({
+      success: true,
+      redirctURI: redirectTo
+    });
+
+    res.cookies.delete(COOKIE_ACCESS_TOKEN_KEY);
+    res.cookies.delete(COOKIE_REFRESH_TOKEN_KEY);
+    return res;
+  } catch (e) {
+    const err = e as Error;
+    return NextResponse.json({
+      success: false,
+      error: err.message,
+      status: 400
+    });
+  }
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -6,7 +6,6 @@ import {
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
-  console.log('logout');
   const cookies = req.cookies;
   const redirectPath = cookies.get('redirectUrl')?.value || '/';
   const redirectTo = `${req.nextUrl.origin}${decodeURIComponent(redirectPath)}`;

--- a/src/app/api/auth/shelter/login/route.ts
+++ b/src/app/api/auth/shelter/login/route.ts
@@ -1,0 +1,44 @@
+import { loginShelter } from '@/api/shelter/auth/login';
+import {
+  COOKIE_ACCESS_TOKEN_KEY,
+  COOKIE_REFRESH_TOKEN_KEY
+} from '@/constants/cookieKeys';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const cookies = req.cookies;
+  const redirectPath = cookies.get('redirectUrl')?.value || '/';
+  const redirectTo = `${req.nextUrl.origin}${decodeURIComponent(redirectPath)}`;
+  const { email = '', password = '' } = await req.json();
+
+  try {
+    if (!email || !password) {
+      throw new Error('이메일과 비밀번호를 입력해주세요.');
+    }
+    const { accessToken, refreshToken } = await loginShelter({
+      email,
+      password
+    });
+    const res = NextResponse.json({
+      redirectURI: redirectTo,
+      success: true,
+      status: 200
+    });
+
+    res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, {
+      sameSite: 'strict',
+      httpOnly: true
+    });
+    res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, {
+      sameSite: 'strict',
+      httpOnly: true
+    });
+    return res;
+  } catch (e) {
+    const err = e as Error;
+    return NextResponse.json({
+      error: err.message,
+      status: 400
+    });
+  }
+}

--- a/src/app/api/auth/token/route.ts
+++ b/src/app/api/auth/token/route.ts
@@ -1,0 +1,47 @@
+import { fetchRefresh } from '@/api/auth/volunteer/refresh';
+import {
+  COOKIE_ACCESS_TOKEN_KEY,
+  COOKIE_REFRESH_TOKEN_KEY
+} from '@/constants/cookieKeys';
+import { NextRequest, NextResponse } from 'next/server';
+
+export default async function GET(req: NextRequest) {
+  const cookies = req.cookies;
+  const beforeAccessToken = cookies.get(COOKIE_ACCESS_TOKEN_KEY)?.value;
+  const beforeRefreshToken = cookies.get(COOKIE_REFRESH_TOKEN_KEY)?.value;
+  try {
+    if (!(beforeAccessToken && beforeRefreshToken)) {
+      throw new Error(
+        `${beforeAccessToken || 'accessToken'} ${
+          beforeRefreshToken || 'refreshToken'
+        } is not exist`
+      );
+    }
+    const data = await fetchRefresh({
+      accessToken: beforeAccessToken,
+      refreshToken: beforeRefreshToken
+    });
+
+    const { accessToken, refreshToken } = data;
+    const res = NextResponse.json({
+      accessToken,
+      refreshToken
+    });
+
+    res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, {
+      sameSite: 'strict',
+      httpOnly: true
+    });
+    res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, {
+      sameSite: 'strict',
+      httpOnly: true
+    });
+    return res;
+  } catch (e) {
+    const err = e as Error;
+    return NextResponse.json({
+      success: false,
+      message: err.message
+    });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,6 @@ import * as styles from './layout.css';
 import Footer from '@/components/common/Footer/Footer';
 import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/cookieKeys';
 import { cookies } from 'next/headers';
-import { setStore } from '@/api/instance';
 
 export const metadata = {
   metadataBase: new URL('https://dangledangle.vercel.app'),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -48,7 +48,7 @@ export default function RootLayout({
       <body className={styles.container}>
         <RecoilRootWrapper>
           <QueryProvider>
-            <AuthProvider>
+            <AuthProvider token={store[COOKIE_ACCESS_TOKEN_KEY]}>
               <div id={PORTAL_ELEMENT_ID.modal} />
               <GlobalComponents />
               <ServerSideHeader />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,9 @@ import font from '@/styles/font';
 import '@/styles/global.css';
 import * as styles from './layout.css';
 import Footer from '@/components/common/Footer/Footer';
+import { cookies } from 'next/headers';
+import { store, setStore } from '@/api/instance';
+import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/cookieKeys';
 
 export const metadata = {
   metadataBase: new URL('https://dangledangle.vercel.app'),
@@ -34,6 +37,12 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  cookies()
+    .getAll()
+    .forEach(({ name, value }) => {
+      setStore(name, value);
+    });
+
   return (
     <html lang="ko" className={font.className}>
       <body className={styles.container}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,9 +9,9 @@ import font from '@/styles/font';
 import '@/styles/global.css';
 import * as styles from './layout.css';
 import Footer from '@/components/common/Footer/Footer';
-import { cookies } from 'next/headers';
-import { store, setStore } from '@/api/instance';
 import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/cookieKeys';
+import { cookies } from 'next/headers';
+import { setStore } from '@/api/instance';
 
 export const metadata = {
   metadataBase: new URL('https://dangledangle.vercel.app'),
@@ -37,18 +37,14 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  cookies()
-    .getAll()
-    .forEach(({ name, value }) => {
-      setStore(name, value);
-    });
+  const initToken = cookies().get(COOKIE_ACCESS_TOKEN_KEY)?.value || '';
 
   return (
     <html lang="ko" className={font.className}>
       <body className={styles.container}>
         <RecoilRootWrapper>
           <QueryProvider>
-            <AuthProvider token={store[COOKIE_ACCESS_TOKEN_KEY]}>
+            <AuthProvider initToken={initToken}>
               <div id={PORTAL_ELEMENT_ID.modal} />
               <GlobalComponents />
               <ServerSideHeader />

--- a/src/app/login/shelter/page.tsx
+++ b/src/app/login/shelter/page.tsx
@@ -44,9 +44,8 @@ export default function ShelterLogin() {
         const redirectTo = `${location.origin}${decodeURIComponent(
           redirectPath
         )}`;
-
         await mutateAsync(data);
-        router.push(redirectTo);
+        location.href = redirectTo;
       } catch (e) {
         toastOn('로그인에 실패했습니다.');
         setError(

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,11 @@ export default async function HomePage() {
     }
 
     if (role === 'VOLUNTEER') {
-      const { nickName: volunteerName } = await volunteer.get();
+      const { nickName: volunteerName } = await volunteer.get({
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
       name = String(volunteerName);
     }
   } catch (e) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,13 +21,12 @@ export default async function HomePage() {
       shelterId = String(dangle_id);
     }
 
-    //TODO : 봉사자 정보 요청에는 권한 필요, 서버쪽에서 어떻게 권한처리 할것인지?
-    // if (role === 'VOLUNTEER') {
-    //   const { nickName: volunteerName } = await volunteer.get();
-    //   console.log(volunteerName);
-    //   name = String(volunteerName);
-    // }
+    if (role === 'VOLUNTEER') {
+      const { nickName: volunteerName } = await volunteer.get();
+      name = String(volunteerName);
+    }
   } catch (e) {
+    console.log('home page error');
     console.log(e);
   }
 

--- a/src/app/register/volunteer/[...slug]/RegisterMain.tsx
+++ b/src/app/register/volunteer/[...slug]/RegisterMain.tsx
@@ -128,6 +128,9 @@ export default function RegisterMain() {
     } catch (e) {
       const { error, formName } = e as RegisterStepError;
 
+      //에러 시 가입 email 정보 삭제
+      Cookies.remove(COOKIE_REGISTER_EMAIL_KEY);
+
       // 이메일중복, 닉네임중복의 경우 exception코드 API-001로 전달받음, 이 경우 로그인 페이지로 이동
       if (error?.exceptionCode === ExceptionCode.UNHANDLED_ERROR) {
         return redirect(
@@ -135,6 +138,16 @@ export default function RegisterMain() {
           '회원가입 과정에서 오류가 발생했습니다.'
         );
       }
+
+      // 이메일 유효 토큰 만료
+      if (error?.exceptionCode === ExceptionCode.UNAUTHORIZED) {
+        return redirect(
+          VOLUNTEER_REDIRECT_PATH_LOGIN,
+          error.message ||
+            '알수없는 오류가 발생했습니다. 회원가입을 다시 진행해주세요.'
+        );
+      }
+
       if (error)
         methods.setError(
           formName,

--- a/src/app/volunteer/redirect/route.ts
+++ b/src/app/volunteer/redirect/route.ts
@@ -49,12 +49,12 @@ export async function GET(req: NextRequest) {
     const res = NextResponse.redirect(redirectTo);
 
     res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, {
-      sameSite: 'lax',
-      httpOnly: false
+      sameSite: 'strict',
+      httpOnly: true
     });
     res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, {
-      sameSite: 'lax',
-      httpOnly: false
+      sameSite: 'strict',
+      httpOnly: true
     });
     return res;
   } catch (e) {

--- a/src/components/home/UpcommingSchedule/ScheduleCard.tsx
+++ b/src/components/home/UpcommingSchedule/ScheduleCard.tsx
@@ -32,6 +32,7 @@ interface ScheduleCardProps {
   joinNum?: number;
   participantNum?: number;
   waitingNum: number;
+  volunteerEventId: number;
 }
 
 export default function ScheduleCard({
@@ -45,11 +46,12 @@ export default function ScheduleCard({
   recruitNum,
   joinNum,
   participantNum,
-  waitingNum
+  waitingNum,
+  volunteerEventId
 }: ScheduleCardProps) {
   const router = useRouter();
   const moveTo = () => {
-    router.push(`/shelter/${shelterId}`);
+    router.push(`/shelter/${shelterId}/event/${volunteerEventId}`);
   };
   const eventDay = `${formatKoDate(startAt)} ${getLocaleWeekday(startAt)}`;
   const duringTime = `${pmamConvert(startAt)} - ${pmamConvert(

--- a/src/components/home/UpcommingSchedule/UpcommingScheduleSection.tsx
+++ b/src/components/home/UpcommingSchedule/UpcommingScheduleSection.tsx
@@ -53,10 +53,10 @@ function VolunteerUserEventList() {
       {volunteerEvents?.length ? (
         volunteerEvents?.map((item, i) => (
           <ScheduleCard
-            shelterId={0} // api 연동 필요
+            {...item}
             key={`schedule_${i}_${item.volunteerEventId}`}
             userRole="VOLUNTEER"
-            {...item}
+            shelterId={item.shelterId!}
           />
         ))
       ) : (
@@ -91,10 +91,10 @@ function ShelterUserEventList() {
       {volunteerEvents?.length ? (
         volunteerEvents?.map((item, i) => (
           <ScheduleCard
+            {...item}
             shelterId={shelterId!}
             key={`schedule_${i}_${item.volunteerEventId}`}
             userRole="SHELTER"
-            {...item}
           />
         ))
       ) : (

--- a/src/components/mypage/EventHistory/EventHistory.tsx
+++ b/src/components/mypage/EventHistory/EventHistory.tsx
@@ -1,4 +1,8 @@
-import { MypageEvent } from '@/api/mypage/event/event';
+import {
+  MyShelterEvent,
+  MyVolunteerEvent,
+  MypageEvent
+} from '@/api/mypage/event/event';
 import ChipInput, { ChipOption } from '@/components/common/ChipInput/ChipInput';
 import DeferredComponent from '@/components/common/Skeleton/DeferredComponent';
 import SkeletonList from '@/components/common/Skeleton/SkeletonList';
@@ -9,7 +13,7 @@ import * as styles from './EventHistory.css';
 import { ShelterFilter, VolunteerFilter } from './hooks/useEventFilter';
 
 interface EventHistoryProps {
-  data: InfiniteData<MypageEvent>;
+  data: InfiniteData<MypageEvent<MyShelterEvent | MyVolunteerEvent>>;
   isLoading: boolean;
   isVolunteer: boolean;
   shelterFilter: Record<string, VolunteerFilter | ShelterFilter>;

--- a/src/components/mypage/EventHistory/hooks/useEventScroll.tsx
+++ b/src/components/mypage/EventHistory/hooks/useEventScroll.tsx
@@ -1,4 +1,8 @@
-import { MypageEvent } from '@/api/mypage/event/event';
+import {
+  MyShelterEvent,
+  MyVolunteerEvent,
+  MypageEvent
+} from '@/api/mypage/event/event';
 import { useScroll } from '@/hooks/useScroll';
 import {
   FetchNextPageOptions,
@@ -12,7 +16,12 @@ interface useEventScrollProps {
   hasNextPage: boolean | undefined;
   fetchNextPage: (
     options?: FetchNextPageOptions | undefined
-  ) => Promise<InfiniteQueryObserverResult<MypageEvent, unknown>>;
+  ) => Promise<
+    InfiniteQueryObserverResult<
+      MypageEvent<MyShelterEvent | MyVolunteerEvent>,
+      unknown
+    >
+  >;
   shelterFilter: Record<string, VolunteerFilter | ShelterFilter>;
 }
 

--- a/src/providers/AuthContext.tsx
+++ b/src/providers/AuthContext.tsx
@@ -71,16 +71,19 @@ const AuthContext = createContext<AuthContextProps>({
   logout: () => {}
 });
 
-const AuthProvider = ({ children }: PropsWithChildren) => {
+const AuthProvider = ({
+  token,
+  children
+}: PropsWithChildren & {
+  token: string | null;
+}) => {
   const [authState, setAuthState] = useState(initialAuthState);
   const router = useRouter();
   const pathname = usePathname();
 
   useEffect(() => {
-    const dangle_access_token = cookie.get(COOKIE_ACCESS_TOKEN_KEY);
-
-    if (dangle_access_token) {
-      const decoded = jwt.decode(dangle_access_token);
+    if (token) {
+      const decoded = jwt.decode(token);
       const isDecodeToken = (decoded: any): decoded is DecodeToken => {
         return (
           decoded &&

--- a/src/providers/AuthContext.tsx
+++ b/src/providers/AuthContext.tsx
@@ -79,11 +79,7 @@ const AuthProvider = ({
   const router = useRouter();
   const pathname = usePathname();
 
-  useEffect(() => {
-    if (initToken && token) {
-      setStore(COOKIE_ACCESS_TOKEN_KEY, initToken);
-    }
-  }, [initToken, token]);
+  initToken && setStore(COOKIE_ACCESS_TOKEN_KEY, initToken);
 
   useEffect(() => {
     if (token) {

--- a/src/utils/ky/hooks/afterResponse.ts
+++ b/src/utils/ky/hooks/afterResponse.ts
@@ -1,47 +1,34 @@
 import ky, { AfterResponseHook } from 'ky';
 import Cookies from 'js-cookie';
-import {
-  COOKIE_ACCESS_TOKEN_KEY,
-  COOKIE_REDIRECT_URL,
-  COOKIE_REFRESH_TOKEN_KEY
-} from '@/constants/cookieKeys';
-import { fetchRefresh } from '@/api/auth/volunteer/refresh';
+import { COOKIE_REDIRECT_URL } from '@/constants/cookieKeys';
+import { getRefresh } from '@/api/auth/volunteer/refresh';
 import { ApiErrorResponse } from '@/types/apiTypes';
 import { ExceptionCode } from '@/constants/exceptionCode';
 
-export const retryRequestOnUnauthorized: AfterResponseHook = async (
-  request,
-  options,
-  response
-) => {
-  const data = await response.json();
+type AfterResponseHookWithProcess = (
+  process: NodeJS.Process
+) => AfterResponseHook;
 
-  if (data.exceptionCode === ExceptionCode.UNAUTHENTICATED) {
-    const accessToken = Cookies.get(COOKIE_ACCESS_TOKEN_KEY);
-    const refreshToken = Cookies.get(COOKIE_REFRESH_TOKEN_KEY);
-
-    if (!accessToken || !refreshToken) {
-      throw new Error('Access token or refresh token is missing');
+export const retryRequestOnUnauthorized: AfterResponseHookWithProcess =
+  process => async (request, options, response) => {
+    console.log('ky에서 에러를잡자', response);
+    if (
+      !(process.env?.NEXT_RUNTIME === 'nodejs') &&
+      !(process.env?.NEXT_RUNTIME === 'edge')
+    ) {
+      const data = await response.json();
+      console.log(data, 'data');
+      if (data.exceptionCode === ExceptionCode.UNAUTHENTICATED) {
+        const data = await getRefresh();
+        if (data.success === true) {
+          return ky(request, options);
+        } else {
+          window.location.href = '/login';
+          return;
+        }
+      }
     }
-
-    const payload = {
-      accessToken,
-      refreshToken
-    };
-
-    Cookies.remove(COOKIE_ACCESS_TOKEN_KEY);
-    Cookies.remove(COOKIE_REFRESH_TOKEN_KEY);
-    const data = await fetchRefresh(payload);
-
-    const newAccessToken = data.accessToken;
-    const newRefreshToken = data.refreshToken;
-
-    Cookies.set(COOKIE_ACCESS_TOKEN_KEY, newAccessToken);
-    Cookies.set(COOKIE_REFRESH_TOKEN_KEY, newRefreshToken);
-
-    return ky(request, options);
-  }
-};
+  };
 
 /** api 요청 과정에서 에러 발생시
  *  ky 에러가 아닌 서버에서 전달받은 에러 throw

--- a/src/utils/ky/hooks/beforeRequest.ts
+++ b/src/utils/ky/hooks/beforeRequest.ts
@@ -1,6 +1,7 @@
 import { BeforeRequestHook } from 'ky';
 import Cookies from 'js-cookie';
 import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/cookieKeys';
+import { store } from '@/api/instance';
 
 type BeforeRequestHookWithProcess = (
   process: NodeJS.Process
@@ -8,11 +9,21 @@ type BeforeRequestHookWithProcess = (
 
 export const setAuthorizationHeader: BeforeRequestHookWithProcess =
   process => async (request, options) => {
-    if (process.env?.NEXT_RUNTIME === 'nodejs') return;
-
-    const accessToken = Cookies.get(COOKIE_ACCESS_TOKEN_KEY);
-
-    if (accessToken)
-      request.headers.set('Authorization', `Bearer ${accessToken}`);
-    else request.headers.delete('Authorization');
+    if (
+      process.env?.NEXT_RUNTIME === 'nodejs' ||
+      process.env?.NEXT_RUNTIME === 'edge'
+    ) {
+      const accessToken = store[COOKIE_ACCESS_TOKEN_KEY];
+      if (accessToken) {
+        request.headers.set('Authorization', `Bearer ${accessToken}`);
+      }
+      return;
+    } else {
+      const accessToken = Cookies.get(COOKIE_ACCESS_TOKEN_KEY);
+      if (accessToken) {
+        request.headers.set('Authorization', `Bearer ${accessToken}`);
+      } else {
+        request.headers.delete('Authorization');
+      }
+    }
   };

--- a/src/utils/ky/hooks/beforeRequest.ts
+++ b/src/utils/ky/hooks/beforeRequest.ts
@@ -1,5 +1,4 @@
 import { BeforeRequestHook } from 'ky';
-import Cookies from 'js-cookie';
 import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/cookieKeys';
 import { store } from '@/api/instance';
 
@@ -10,20 +9,15 @@ type BeforeRequestHookWithProcess = (
 export const setAuthorizationHeader: BeforeRequestHookWithProcess =
   process => async (request, options) => {
     if (
-      process.env?.NEXT_RUNTIME === 'nodejs' ||
-      process.env?.NEXT_RUNTIME === 'edge'
+      !(process.env?.NEXT_RUNTIME === 'nodejs') &&
+      !(process.env?.NEXT_RUNTIME === 'edge')
     ) {
       const accessToken = store[COOKIE_ACCESS_TOKEN_KEY];
       if (accessToken) {
-        request.headers.set('Authorization', `Bearer ${accessToken}`);
-      }
-      return;
-    } else {
-      const accessToken = Cookies.get(COOKIE_ACCESS_TOKEN_KEY);
-      if (accessToken) {
+        request.headers.delete('Authorization');
         request.headers.set('Authorization', `Bearer ${accessToken}`);
       } else {
-        request.headers.delete('Authorization');
+        throw new Error('accessToken is not exist');
       }
     }
   };


### PR DESCRIPTION
## 스크린샷
<img width="392" alt="image" src="https://github.com/YAPP-Github/dangledangle-client/assets/66112027/a82ab386-5275-4edc-addf-1a2a2426fa43">

<br>

## Motivation

- [feat/YW-208](https://yapp22-web2.atlassian.net/browse/YW2-208?atlOrigin=eyJpIjoiMjhhMTBlNTU3MTZiNGYxMThmMWM4NTFkYzg5YjdmNjYiLCJwIjoiaiJ9)

- 로그인 이후 사용자의 엑세스토큰을 쿠키에 저장하고 있었고, 유저의 로그인 정보를 프로젝트 전반적으로 사용하기 위해 authContext라는 React contextAPI를 통해 사용하고 있었습니다. 
- 쿠키에 있는 값을 브라우저 내에서 핸들링해야 했으므로 부득이하게 `httponly` 속성을 제거하고 사용했는데 이 경우 xss 공격에 취약하므로 수정이 필요했습니다.
- next 서버에 페이지 리소스를 요청하는 과정에서 브라우저의 쿠키가 전달되고 있으므로 쿠키에 있는 토큰 값을 꺼내서 서버사이드에서 api 서버에 요청이 필요할 때 사용합니다(홈페이지에 유저 이름을 띄워줘야 할 때 토큰이 필요)
- 보안을 위해 쿠키에 httponly 속성 추가했고 그 이유로 클라이언트 사이드에서 쿠키값을 읽을 수 없으므로  토큰 값을 authContext Provider에 props로 넘겨서 클라이언트 사이드에서도 authContext를 사용할 수 있도록 했습니다.

<br>

## To Reviewers

- 

### Key Changes

- ~가 변경되었습니다.
