### PR TITLE
[Feat] 엑세스토큰,쿠키 처리 로직 관련 구현

### DIFF
--- a/src/api/auth/volunteer/refresh.ts
+++ b/src/api/auth/volunteer/refresh.ts
@@ -1,17 +1,31 @@
 import api from '@/api/instance';
+import ky from 'ky';
 
 export type LoginResponse = {
   accessToken: string;
   refreshToken: string;
 };
-type LoginPayload = LoginResponse;
+export type LoginPayload = LoginResponse;
 
-export const fetchRefresh = async (data: LoginPayload) => {
+export const fetchRefresh = async (data: LoginResponse) => {
   const response = await api
     .post(`auth/token/refresh`, {
       json: data
     })
     .then(res => res.json<LoginResponse>());
+  return response;
+};
+
+export const getRefresh = async () => {
+  const response = await ky
+    .get(`auth/token/refresh`, {
+      prefixUrl: process.env.NEXT_PUBLIC_FRONT_ENDPOINT
+    })
+    .then(res =>
+      res.json<{
+        success: boolean;
+      }>()
+    );
 
   return response;
 };

--- a/src/api/auth/volunteer/refresh.ts
+++ b/src/api/auth/volunteer/refresh.ts
@@ -1,5 +1,4 @@
-import api from '@/api/instance';
-import ky from 'ky';
+import api, { fe } from '@/api/instance';
 
 export type LoginResponse = {
   accessToken: string;
@@ -17,15 +16,11 @@ export const fetchRefresh = async (data: LoginResponse) => {
 };
 
 export const getRefresh = async () => {
-  const response = await ky
-    .get(`auth/token/refresh`, {
-      prefixUrl: process.env.NEXT_PUBLIC_FRONT_ENDPOINT
-    })
-    .then(res =>
-      res.json<{
-        success: boolean;
-      }>()
-    );
+  const response = await fe.get(`auth/token/refresh`).then(res =>
+    res.json<{
+      success: boolean;
+    }>()
+  );
 
   return response;
 };

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -6,7 +6,17 @@ import {
   throwServerErrorMessage
 } from '@/utils/ky/hooks/afterResponse';
 
-const api = ky.create({
+/**
+ * cookie에 있는 authroitoken 저장하는 공간,
+ * beforeRequest 훅에서 여기 있는 store를 꺼내서 헤더에 넣어준다.
+ */
+export const store: { [key in string]: string } = {};
+
+export const setStore = (key: string, value: string) => {
+  store[key] = value;
+};
+
+const api = ky.extend({
   prefixUrl: process.env.NEXT_PUBLIC_API_ENDPOINT,
   headers: {
     'Content-Type': 'application/json'

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -7,7 +7,7 @@ import {
 } from '@/utils/ky/hooks/afterResponse';
 
 /**
- * cookie에 있는 authroitoken 저장하는 공간,
+ * client 사이드에서 httponly 쿠키 사용이 불가능하므로 객체에 저장
  * beforeRequest 훅에서 여기 있는 store를 꺼내서 헤더에 넣어준다.
  */
 export const store: { [key in string]: string } = {};
@@ -15,6 +15,7 @@ export const store: { [key in string]: string } = {};
 export const setStore = (key: string, value: string) => {
   store[key] = value;
 };
+export const removeStore = (key: string) => {};
 
 const api = ky.extend({
   prefixUrl: process.env.NEXT_PUBLIC_API_ENDPOINT,

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -25,7 +25,7 @@ const api = ky.extend({
   hooks: {
     beforeRequest: [setAuthorizationHeader(process)],
     afterResponse: [
-      retryRequestOnUnauthorized,
+      retryRequestOnUnauthorized(process),
       throwServerErrorMessage,
       deleteClientCokiesPath
     ]

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -32,8 +32,18 @@ const api = ky.extend({
   }
 });
 
+const url = (() => {
+  const branch = process?.env.NEXT_PUBLIC_VERCEL_BRANCH_URL || '';
+
+  if (branch.match(/feat/)) {
+    return `https://${process?.env.NEXT_PUBLIC_VERCEL_BRANCH_URL}/api`;
+  } else {
+    return process?.env.NEXT_PUBLIC_FRONT_ENDPOINT;
+  }
+})();
+
 export const fe = ky.extend({
-  prefixUrl: process.env.NEXT_PUBLIC_FRONT_ENDPOINT
+  prefixUrl: url
 });
 
 export default api;

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -32,4 +32,8 @@ const api = ky.extend({
   }
 });
 
+export const fe = ky.extend({
+  prefixUrl: process.env.NEXT_PUBLIC_FRONT_ENDPOINT
+});
+
 export default api;

--- a/src/api/mypage/event/event.ts
+++ b/src/api/mypage/event/event.ts
@@ -6,10 +6,10 @@ export const queryKey = {
   all: ['volunteer-event', 'admin'] as const
 };
 
-export interface MypageEvent {
+export interface MypageEvent<T extends MyShelterEvent | MyVolunteerEvent> {
   pageNumber: number;
   pageSize: number;
-  content: MyShelterEvent[] | MyVolunteerEvent[];
+  content: T[];
 }
 
 export interface MyBaseEvent {
@@ -43,7 +43,7 @@ export const getMyShelterEvent = async (filter: MypageEventParams) => {
 
   const response = await api
     .get(`shelter/admin/my/volunteer-event${queryParameters}`)
-    .then(res => res.json<MypageEvent>());
+    .then(res => res.json<MypageEvent<MyShelterEvent>>());
   return response;
 };
 
@@ -52,6 +52,6 @@ export const getMyVolEvent = async (filter: MypageEventParams) => {
 
   const response = await api
     .get(`volunteer/my/volunteer-event${queryParameters}`)
-    .then(res => res.json<MypageEvent>());
+    .then(res => res.json<MypageEvent<MyVolunteerEvent>>());
   return response;
 };

--- a/src/api/mypage/event/useMyShelterEvent.tsx
+++ b/src/api/mypage/event/useMyShelterEvent.tsx
@@ -3,6 +3,7 @@ import {
   useInfiniteQuery
 } from '@tanstack/react-query';
 import {
+  MyShelterEvent,
   MypageEvent,
   MypageEventParams,
   getMyShelterEvent,
@@ -11,9 +12,9 @@ import {
 
 export default function useMyShelterEvent(
   filter?: MypageEventParams,
-  options?: UseInfiniteQueryOptions<MypageEvent>
+  options?: UseInfiniteQueryOptions<MypageEvent<MyShelterEvent>>
 ) {
-  return useInfiniteQuery<MypageEvent>(
+  return useInfiniteQuery<MypageEvent<MyShelterEvent>>(
     [...queryKey.all, JSON.stringify(filter)],
     ({ pageParam = 0 }) => getMyShelterEvent({ ...filter, page: pageParam }),
     {

--- a/src/api/mypage/event/useMyVolEvent.tsx
+++ b/src/api/mypage/event/useMyVolEvent.tsx
@@ -3,6 +3,7 @@ import {
   useInfiniteQuery
 } from '@tanstack/react-query';
 import {
+  MyVolunteerEvent,
   MypageEvent,
   MypageEventParams,
   getMyVolEvent,
@@ -11,9 +12,9 @@ import {
 
 export default function useMyVolEvent(
   filter?: MypageEventParams,
-  options?: UseInfiniteQueryOptions<MypageEvent>
+  options?: UseInfiniteQueryOptions<MypageEvent<MyVolunteerEvent>>
 ) {
-  return useInfiniteQuery<MypageEvent>(
+  return useInfiniteQuery<MypageEvent<MyVolunteerEvent>>(
     [...queryKey.all, JSON.stringify(filter)],
     ({ pageParam = 0 }) => getMyVolEvent({ ...filter, page: pageParam }),
     {

--- a/src/api/mypage/mypage.ts
+++ b/src/api/mypage/mypage.ts
@@ -1,3 +1,4 @@
+import { Options } from 'ky';
 import api from '../instance';
 
 export const queryKey = {
@@ -58,8 +59,10 @@ export const getShelterInfo = async () => {
   return response;
 };
 
-export const logout = async () => {
-  const response = await api.get(`auth/logout`).then(res => res.json<string>());
+export const logout = async (options?: Options) => {
+  const response = await api
+    .get(`auth/logout`, options)
+    .then(res => res.json<string>());
   return response;
 };
 

--- a/src/api/mypage/useLogout.tsx
+++ b/src/api/mypage/useLogout.tsx
@@ -1,32 +1,26 @@
-import { initialAuthState, useAuthContext } from '@/providers/AuthContext';
+import { useAuthContext } from '@/providers/AuthContext';
 import { useMutation } from '@tanstack/react-query';
-import { logout } from './mypage';
-import Cookies from 'js-cookie';
-import {
-  COOKIE_ACCESS_TOKEN_KEY,
-  COOKIE_REFRESH_TOKEN_KEY
-} from '@/constants/cookieKeys';
-import { useRouter } from 'next/navigation';
 import useToast from '@/hooks/useToast';
+import ky from 'ky';
 
 export default function useLogout() {
-  const { setAuthState } = useAuthContext();
-  const router = useRouter();
+  const { logout: clientLogout } = useAuthContext();
   const toastOn = useToast();
 
-  return useMutation<string, Error>(logout, {
-    onSuccess: response => {
-      if (Cookies.get(COOKIE_ACCESS_TOKEN_KEY)) {
-        setAuthState(initialAuthState); // AuthContext info delete
-        // client cookies delete
-        Cookies.remove(COOKIE_ACCESS_TOKEN_KEY);
-        Cookies.remove(COOKIE_REFRESH_TOKEN_KEY);
+  const logoutAPI = async () => {
+    const response = await ky
+      .get('auth/logout', {
+        prefixUrl: process?.env.NEXT_PUBLIC_FRONT_ENDPOINT
+      })
+      .then(res => res.json<string>());
+    return response;
+  };
 
-        router.push('/login');
-        toastOn('로그아웃이 완료되었습니다.');
-      } else {
-        console.error(response);
-      }
+  return useMutation<string, Error>(logoutAPI, {
+    onSuccess: response => {
+      clientLogout();
+      location.href = '/login';
+      toastOn('로그아웃이 완료되었습니다.');
     },
     onError: error => {
       console.error('Logout error:', error);

--- a/src/api/mypage/useLogout.tsx
+++ b/src/api/mypage/useLogout.tsx
@@ -1,17 +1,15 @@
 import { useAuthContext } from '@/providers/AuthContext';
 import { useMutation } from '@tanstack/react-query';
 import useToast from '@/hooks/useToast';
-import ky from 'ky';
+import { fe } from '../instance';
 
 export default function useLogout() {
   const { logout: clientLogout } = useAuthContext();
   const toastOn = useToast();
 
   const logoutAPI = async () => {
-    const response = await ky
-      .get('auth/logout', {
-        prefixUrl: process?.env.NEXT_PUBLIC_FRONT_ENDPOINT
-      })
+    const response = await fe
+      .get('auth/logout')
       .then(res => res.json<string>());
     return response;
   };

--- a/src/api/mypage/useMyInfo.tsx
+++ b/src/api/mypage/useMyInfo.tsx
@@ -12,7 +12,6 @@ export default function useMyInfo(
   options?: UseQueryOptions<MyVolInfo | MyShelterInfo>
 ) {
   const fetchData = async () => {
-    console.log(role);
     if (role === 'SHELTER') {
       return await getShelterInfo();
     } else {
@@ -21,6 +20,9 @@ export default function useMyInfo(
   };
 
   return useQuery<MyVolInfo | MyShelterInfo>(queryKey.all, fetchData, {
-    ...options
+    ...options,
+    onError(err) {
+      console.log(err);
+    }
   });
 }

--- a/src/api/shelter/auth/login.ts
+++ b/src/api/shelter/auth/login.ts
@@ -6,12 +6,10 @@ export interface LoginPayload {
   password: string;
 }
 
-export type LoginResponse =
-  | {
-      accessToken: string;
-      refreshToken: string;
-    }
-  | ApiErrorResponse;
+export type LoginResponse = {
+  accessToken: string;
+  refreshToken: string;
+};
 
 export const loginShelter = async (data: LoginPayload) => {
   const response = await api

--- a/src/api/shelter/auth/useShelterLogin.ts
+++ b/src/api/shelter/auth/useShelterLogin.ts
@@ -1,26 +1,35 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { LoginPayload, LoginResponse, loginShelter } from './login';
-import Cookies from 'js-cookie';
-import {
-  COOKIE_ACCESS_TOKEN_KEY,
-  COOKIE_REFRESH_TOKEN_KEY
-} from '@/constants/cookieKeys';
+import { LoginPayload } from './login';
+import ky from 'ky';
+import { ApiErrorResponse } from '@/types/apiTypes';
 
 export const shelterAuthKey = {
   all: ['shelterAuth'] as const
 };
 
+export type ShelterLoginResponse = {
+  redirect: string;
+};
+
+const shelterLoginAPI = async (data: LoginPayload) => {
+  const response = await ky
+    .post(`auth/shelter/login`, {
+      json: data,
+      prefixUrl: process.env.NEXT_PUBLIC_FRONT_ENDPOINT
+    })
+    .then(res => res.json<ShelterLoginResponse>());
+
+  return response;
+};
+
 export default function useShelterLogin() {
   const queryClient = useQueryClient();
-  return useMutation<LoginResponse, Error, LoginPayload>(loginShelter, {
-    onSuccess: response => {
-      if ('accessToken' in response) {
-        Cookies.set(COOKIE_ACCESS_TOKEN_KEY, response.accessToken);
-        Cookies.set(COOKIE_REFRESH_TOKEN_KEY, response.refreshToken);
-        return queryClient.invalidateQueries(shelterAuthKey.all);
-      } else {
-        console.error(response);
+  return useMutation<ShelterLoginResponse, ApiErrorResponse, LoginPayload>(
+    shelterLoginAPI,
+    {
+      onSuccess: response => {
+        queryClient.invalidateQueries(shelterAuthKey.all);
       }
     }
-  });
+  );
 }

--- a/src/api/shelter/auth/useShelterLogin.ts
+++ b/src/api/shelter/auth/useShelterLogin.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { LoginPayload } from './login';
-import ky from 'ky';
 import { ApiErrorResponse } from '@/types/apiTypes';
+import { fe } from '@/api/instance';
 
 export const shelterAuthKey = {
   all: ['shelterAuth'] as const
@@ -12,10 +12,9 @@ export type ShelterLoginResponse = {
 };
 
 const shelterLoginAPI = async (data: LoginPayload) => {
-  const response = await ky
+  const response = await fe
     .post(`auth/shelter/login`, {
-      json: data,
-      prefixUrl: process.env.NEXT_PUBLIC_FRONT_ENDPOINT
+      json: data
     })
     .then(res => res.json<ShelterLoginResponse>());
 

--- a/src/api/volunteer/my/index.ts
+++ b/src/api/volunteer/my/index.ts
@@ -1,4 +1,5 @@
 import api from '@/api/instance';
+import { Options } from 'ky';
 
 export interface VolunteerMyResponse {
   nickName: string;
@@ -11,6 +12,6 @@ export interface VolunteerMyResponse {
   alarm: boolean;
 }
 
-export const get = async () => {
-  return await api.get('volunteer/my').json<VolunteerMyResponse>();
+export const get = async (option: Options) => {
+  return await api.get('volunteer/my', option).json<VolunteerMyResponse>();
 };

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,39 @@
+import { logout } from '@/api/mypage/mypage';
+import {
+  COOKIE_ACCESS_TOKEN_KEY,
+  COOKIE_REFRESH_TOKEN_KEY
+} from '@/constants/cookieKeys';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  console.log('logout');
+  const cookies = req.cookies;
+  const redirectPath = cookies.get('redirectUrl')?.value || '/';
+  const redirectTo = `${req.nextUrl.origin}${decodeURIComponent(redirectPath)}`;
+  const accessToken = cookies.get(COOKIE_ACCESS_TOKEN_KEY)?.value;
+
+  try {
+    if (!accessToken) throw new Error('accessToken is not exist');
+    await logout({
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    });
+
+    const res = NextResponse.json({
+      success: true,
+      redirctURI: redirectTo
+    });
+
+    res.cookies.delete(COOKIE_ACCESS_TOKEN_KEY);
+    res.cookies.delete(COOKIE_REFRESH_TOKEN_KEY);
+    return res;
+  } catch (e) {
+    const err = e as Error;
+    return NextResponse.json({
+      success: false,
+      error: err.message,
+      status: 400
+    });
+  }
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -6,7 +6,6 @@ import {
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
-  console.log('logout');
   const cookies = req.cookies;
   const redirectPath = cookies.get('redirectUrl')?.value || '/';
   const redirectTo = `${req.nextUrl.origin}${decodeURIComponent(redirectPath)}`;

--- a/src/app/api/auth/shelter/login/route.ts
+++ b/src/app/api/auth/shelter/login/route.ts
@@ -1,0 +1,44 @@
+import { loginShelter } from '@/api/shelter/auth/login';
+import {
+  COOKIE_ACCESS_TOKEN_KEY,
+  COOKIE_REFRESH_TOKEN_KEY
+} from '@/constants/cookieKeys';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const cookies = req.cookies;
+  const redirectPath = cookies.get('redirectUrl')?.value || '/';
+  const redirectTo = `${req.nextUrl.origin}${decodeURIComponent(redirectPath)}`;
+  const { email = '', password = '' } = await req.json();
+
+  try {
+    if (!email || !password) {
+      throw new Error('이메일과 비밀번호를 입력해주세요.');
+    }
+    const { accessToken, refreshToken } = await loginShelter({
+      email,
+      password
+    });
+    const res = NextResponse.json({
+      redirectURI: redirectTo,
+      success: true,
+      status: 200
+    });
+
+    res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, {
+      sameSite: 'strict',
+      httpOnly: true
+    });
+    res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, {
+      sameSite: 'strict',
+      httpOnly: true
+    });
+    return res;
+  } catch (e) {
+    const err = e as Error;
+    return NextResponse.json({
+      error: err.message,
+      status: 400
+    });
+  }
+}

--- a/src/app/api/auth/shelter/login/route.ts
+++ b/src/app/api/auth/shelter/login/route.ts
@@ -3,6 +3,8 @@ import {
   COOKIE_ACCESS_TOKEN_KEY,
   COOKIE_REFRESH_TOKEN_KEY
 } from '@/constants/cookieKeys';
+import { getCookieConfig } from '@/utils/token/cookieConfig';
+import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
@@ -25,14 +27,10 @@ export async function POST(req: NextRequest) {
       status: 200
     });
 
-    res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, {
-      sameSite: 'strict',
-      httpOnly: true
-    });
-    res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, {
-      sameSite: 'strict',
-      httpOnly: true
-    });
+    const cookieConfig = getCookieConfig(req);
+
+    res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, cookieConfig);
+    res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, cookieConfig);
     return res;
   } catch (e) {
     const err = e as Error;

--- a/src/app/api/auth/token/route.ts
+++ b/src/app/api/auth/token/route.ts
@@ -3,6 +3,7 @@ import {
   COOKIE_ACCESS_TOKEN_KEY,
   COOKIE_REFRESH_TOKEN_KEY
 } from '@/constants/cookieKeys';
+import { getCookieConfig } from '@/utils/token/cookieConfig';
 import { NextRequest, NextResponse } from 'next/server';
 
 export default async function GET(req: NextRequest) {
@@ -27,15 +28,11 @@ export default async function GET(req: NextRequest) {
       accessToken,
       refreshToken
     });
+    const cookieConfig = getCookieConfig(req);
 
-    res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, {
-      sameSite: 'strict',
-      httpOnly: true
-    });
-    res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, {
-      sameSite: 'strict',
-      httpOnly: true
-    });
+    res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, cookieConfig);
+    res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, cookieConfig);
+
     return res;
   } catch (e) {
     const err = e as Error;

--- a/src/app/api/auth/token/route.ts
+++ b/src/app/api/auth/token/route.ts
@@ -1,0 +1,47 @@
+import { fetchRefresh } from '@/api/auth/volunteer/refresh';
+import {
+  COOKIE_ACCESS_TOKEN_KEY,
+  COOKIE_REFRESH_TOKEN_KEY
+} from '@/constants/cookieKeys';
+import { NextRequest, NextResponse } from 'next/server';
+
+export default async function GET(req: NextRequest) {
+  const cookies = req.cookies;
+  const beforeAccessToken = cookies.get(COOKIE_ACCESS_TOKEN_KEY)?.value;
+  const beforeRefreshToken = cookies.get(COOKIE_REFRESH_TOKEN_KEY)?.value;
+  try {
+    if (!(beforeAccessToken && beforeRefreshToken)) {
+      throw new Error(
+        `${beforeAccessToken || 'accessToken'} ${
+          beforeRefreshToken || 'refreshToken'
+        } is not exist`
+      );
+    }
+    const data = await fetchRefresh({
+      accessToken: beforeAccessToken,
+      refreshToken: beforeRefreshToken
+    });
+
+    const { accessToken, refreshToken } = data;
+    const res = NextResponse.json({
+      accessToken,
+      refreshToken
+    });
+
+    res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, {
+      sameSite: 'strict',
+      httpOnly: true
+    });
+    res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, {
+      sameSite: 'strict',
+      httpOnly: true
+    });
+    return res;
+  } catch (e) {
+    const err = e as Error;
+    return NextResponse.json({
+      success: false,
+      message: err.message
+    });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,6 @@ import * as styles from './layout.css';
 import Footer from '@/components/common/Footer/Footer';
 import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/cookieKeys';
 import { cookies } from 'next/headers';
-import { setStore } from '@/api/instance';
 
 export const metadata = {
   metadataBase: new URL('https://dangledangle.vercel.app'),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -48,7 +48,7 @@ export default function RootLayout({
       <body className={styles.container}>
         <RecoilRootWrapper>
           <QueryProvider>
-            <AuthProvider>
+            <AuthProvider token={store[COOKIE_ACCESS_TOKEN_KEY]}>
               <div id={PORTAL_ELEMENT_ID.modal} />
               <GlobalComponents />
               <ServerSideHeader />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,9 @@ import font from '@/styles/font';
 import '@/styles/global.css';
 import * as styles from './layout.css';
 import Footer from '@/components/common/Footer/Footer';
+import { cookies } from 'next/headers';
+import { store, setStore } from '@/api/instance';
+import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/cookieKeys';
 
 export const metadata = {
   metadataBase: new URL('https://dangledangle.vercel.app'),
@@ -34,6 +37,12 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  cookies()
+    .getAll()
+    .forEach(({ name, value }) => {
+      setStore(name, value);
+    });
+
   return (
     <html lang="ko" className={font.className}>
       <body className={styles.container}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,9 +9,9 @@ import font from '@/styles/font';
 import '@/styles/global.css';
 import * as styles from './layout.css';
 import Footer from '@/components/common/Footer/Footer';
-import { cookies } from 'next/headers';
-import { store, setStore } from '@/api/instance';
 import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/cookieKeys';
+import { cookies } from 'next/headers';
+import { setStore } from '@/api/instance';
 
 export const metadata = {
   metadataBase: new URL('https://dangledangle.vercel.app'),
@@ -37,18 +37,14 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  cookies()
-    .getAll()
-    .forEach(({ name, value }) => {
-      setStore(name, value);
-    });
+  const initToken = cookies().get(COOKIE_ACCESS_TOKEN_KEY)?.value || '';
 
   return (
     <html lang="ko" className={font.className}>
       <body className={styles.container}>
         <RecoilRootWrapper>
           <QueryProvider>
-            <AuthProvider token={store[COOKIE_ACCESS_TOKEN_KEY]}>
+            <AuthProvider initToken={initToken}>
               <div id={PORTAL_ELEMENT_ID.modal} />
               <GlobalComponents />
               <ServerSideHeader />

--- a/src/app/login/shelter/page.tsx
+++ b/src/app/login/shelter/page.tsx
@@ -44,9 +44,8 @@ export default function ShelterLogin() {
         const redirectTo = `${location.origin}${decodeURIComponent(
           redirectPath
         )}`;
-
         await mutateAsync(data);
-        router.push(redirectTo);
+        location.href = redirectTo;
       } catch (e) {
         toastOn('로그인에 실패했습니다.');
         setError(

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,11 @@ export default async function HomePage() {
     }
 
     if (role === 'VOLUNTEER') {
-      const { nickName: volunteerName } = await volunteer.get();
+      const { nickName: volunteerName } = await volunteer.get({
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
       name = String(volunteerName);
     }
   } catch (e) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,13 +21,12 @@ export default async function HomePage() {
       shelterId = String(dangle_id);
     }
 
-    //TODO : 봉사자 정보 요청에는 권한 필요, 서버쪽에서 어떻게 권한처리 할것인지?
-    // if (role === 'VOLUNTEER') {
-    //   const { nickName: volunteerName } = await volunteer.get();
-    //   console.log(volunteerName);
-    //   name = String(volunteerName);
-    // }
+    if (role === 'VOLUNTEER') {
+      const { nickName: volunteerName } = await volunteer.get();
+      name = String(volunteerName);
+    }
   } catch (e) {
+    console.log('home page error');
     console.log(e);
   }
 

--- a/src/app/register/volunteer/[...slug]/RegisterMain.tsx
+++ b/src/app/register/volunteer/[...slug]/RegisterMain.tsx
@@ -128,6 +128,9 @@ export default function RegisterMain() {
     } catch (e) {
       const { error, formName } = e as RegisterStepError;
 
+      //에러 시 가입 email 정보 삭제
+      Cookies.remove(COOKIE_REGISTER_EMAIL_KEY);
+
       // 이메일중복, 닉네임중복의 경우 exception코드 API-001로 전달받음, 이 경우 로그인 페이지로 이동
       if (error?.exceptionCode === ExceptionCode.UNHANDLED_ERROR) {
         return redirect(
@@ -135,6 +138,16 @@ export default function RegisterMain() {
           '회원가입 과정에서 오류가 발생했습니다.'
         );
       }
+
+      // 이메일 유효 토큰 만료
+      if (error?.exceptionCode === ExceptionCode.UNAUTHORIZED) {
+        return redirect(
+          VOLUNTEER_REDIRECT_PATH_LOGIN,
+          error.message ||
+            '알수없는 오류가 발생했습니다. 회원가입을 다시 진행해주세요.'
+        );
+      }
+
       if (error)
         methods.setError(
           formName,

--- a/src/app/volunteer/redirect/route.ts
+++ b/src/app/volunteer/redirect/route.ts
@@ -46,7 +46,9 @@ export async function GET(req: NextRequest) {
     const cookieStore = cookies();
     const redirectPath = cookieStore.get(COOKIE_REDIRECT_URL)?.value || '/';
     const redirectTo = `${originUrl}${decodeURIComponent(redirectPath)}`;
-    const res = NextResponse.redirect(redirectTo);
+    const res = NextResponse.redirect(redirectTo, {
+      status: 308
+    });
 
     res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, {
       sameSite: 'strict',

--- a/src/app/volunteer/redirect/route.ts
+++ b/src/app/volunteer/redirect/route.ts
@@ -49,12 +49,12 @@ export async function GET(req: NextRequest) {
     const res = NextResponse.redirect(redirectTo);
 
     res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, {
-      sameSite: 'lax',
-      httpOnly: false
+      sameSite: 'strict',
+      httpOnly: true
     });
     res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, {
-      sameSite: 'lax',
-      httpOnly: false
+      sameSite: 'strict',
+      httpOnly: true
     });
     return res;
   } catch (e) {

--- a/src/app/volunteer/redirect/route.ts
+++ b/src/app/volunteer/redirect/route.ts
@@ -8,6 +8,7 @@ import {
 import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { VOLUNTEER_REDIRECT_PATH_REGISTER } from '../../register/volunteer/[...slug]/CurrentComponentTypes';
+import { getCookieConfig } from '@/utils/token/cookieConfig';
 
 export async function GET(req: NextRequest) {
   const query = new URL(req.url).searchParams;
@@ -47,17 +48,16 @@ export async function GET(req: NextRequest) {
     const redirectPath = cookieStore.get(COOKIE_REDIRECT_URL)?.value || '/';
     const redirectTo = `${originUrl}${decodeURIComponent(redirectPath)}`;
     const res = NextResponse.redirect(redirectTo, {
-      status: 308
+      status: 308,
+      headers: {
+        locagion: redirectTo
+      }
     });
+    const cookieConfig = getCookieConfig(req);
 
-    res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, {
-      sameSite: 'strict',
-      httpOnly: true
-    });
-    res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, {
-      sameSite: 'strict',
-      httpOnly: true
-    });
+    res.cookies.set(COOKIE_ACCESS_TOKEN_KEY, accessToken, cookieConfig);
+    res.cookies.set(COOKIE_REFRESH_TOKEN_KEY, refreshToken, cookieConfig);
+
     return res;
   } catch (e) {
     console.error(e);

--- a/src/components/common/Header/MainHeader.tsx
+++ b/src/components/common/Header/MainHeader.tsx
@@ -8,7 +8,7 @@ import { palette } from '@/styles/color';
 import { UserRole } from '@/constants/user';
 import useObserver from '@/hooks/useObserver';
 import { DOM_ID_BANNER } from '@/constants/dom';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useAuthContext } from '@/providers/AuthContext';
 
 interface MainHeaderProps {
@@ -18,7 +18,8 @@ interface MainHeaderProps {
 
 export default function MainHeader({ initRole, shelterId }: MainHeaderProps) {
   const router = useRouter();
-  const { dangle_role: role } = useAuthContext();
+  const [role, setRole] = useState(initRole);
+  const { dangle_role } = useAuthContext();
   const refresh = () => {
     router.refresh();
   };
@@ -44,6 +45,12 @@ export default function MainHeader({ initRole, shelterId }: MainHeaderProps) {
       ? '보호소 파트너'
       : '로그인/회원가입';
   }, [initRole, role]);
+
+  useEffect(() => {
+    if (initRole !== role) {
+      setRole(dangle_role);
+    }
+  }, [initRole, role, dangle_role]);
 
   const { toggle } = useObserver(DOM_ID_BANNER);
 

--- a/src/components/home/UpcommingSchedule/ScheduleCard.tsx
+++ b/src/components/home/UpcommingSchedule/ScheduleCard.tsx
@@ -32,6 +32,7 @@ interface ScheduleCardProps {
   joinNum?: number;
   participantNum?: number;
   waitingNum: number;
+  volunteerEventId: number;
 }
 
 export default function ScheduleCard({
@@ -45,11 +46,12 @@ export default function ScheduleCard({
   recruitNum,
   joinNum,
   participantNum,
-  waitingNum
+  waitingNum,
+  volunteerEventId
 }: ScheduleCardProps) {
   const router = useRouter();
   const moveTo = () => {
-    router.push(`/shelter/${shelterId}`);
+    router.push(`/shelter/${shelterId}/event/${volunteerEventId}`);
   };
   const eventDay = `${formatKoDate(startAt)} ${getLocaleWeekday(startAt)}`;
   const duringTime = `${pmamConvert(startAt)} - ${pmamConvert(

--- a/src/components/home/UpcommingSchedule/UpcommingScheduleSection.tsx
+++ b/src/components/home/UpcommingSchedule/UpcommingScheduleSection.tsx
@@ -53,10 +53,10 @@ function VolunteerUserEventList() {
       {volunteerEvents?.length ? (
         volunteerEvents?.map((item, i) => (
           <ScheduleCard
-            shelterId={0} // api 연동 필요
+            {...item}
             key={`schedule_${i}_${item.volunteerEventId}`}
             userRole="VOLUNTEER"
-            {...item}
+            shelterId={item.shelterId!}
           />
         ))
       ) : (
@@ -91,10 +91,10 @@ function ShelterUserEventList() {
       {volunteerEvents?.length ? (
         volunteerEvents?.map((item, i) => (
           <ScheduleCard
+            {...item}
             shelterId={shelterId!}
             key={`schedule_${i}_${item.volunteerEventId}`}
             userRole="SHELTER"
-            {...item}
           />
         ))
       ) : (

--- a/src/components/mypage/EventHistory/EventHistory.tsx
+++ b/src/components/mypage/EventHistory/EventHistory.tsx
@@ -1,4 +1,8 @@
-import { MypageEvent } from '@/api/mypage/event/event';
+import {
+  MyShelterEvent,
+  MyVolunteerEvent,
+  MypageEvent
+} from '@/api/mypage/event/event';
 import ChipInput, { ChipOption } from '@/components/common/ChipInput/ChipInput';
 import DeferredComponent from '@/components/common/Skeleton/DeferredComponent';
 import SkeletonList from '@/components/common/Skeleton/SkeletonList';
@@ -10,7 +14,7 @@ import { ShelterFilter, VolunteerFilter } from './hooks/useEventFilter';
 import clsx from 'clsx';
 
 interface EventHistoryProps {
-  data: InfiniteData<MypageEvent>;
+  data: InfiniteData<MypageEvent<MyShelterEvent | MyVolunteerEvent>>;
   isLoading: boolean;
   isVolunteer: boolean;
   shelterFilter: Record<string, VolunteerFilter | ShelterFilter>;

--- a/src/components/mypage/EventHistory/hooks/useEventScroll.tsx
+++ b/src/components/mypage/EventHistory/hooks/useEventScroll.tsx
@@ -1,4 +1,8 @@
-import { MypageEvent } from '@/api/mypage/event/event';
+import {
+  MyShelterEvent,
+  MyVolunteerEvent,
+  MypageEvent
+} from '@/api/mypage/event/event';
 import { useScroll } from '@/hooks/useScroll';
 import {
   FetchNextPageOptions,
@@ -12,7 +16,12 @@ interface useEventScrollProps {
   hasNextPage: boolean | undefined;
   fetchNextPage: (
     options?: FetchNextPageOptions | undefined
-  ) => Promise<InfiniteQueryObserverResult<MypageEvent, unknown>>;
+  ) => Promise<
+    InfiniteQueryObserverResult<
+      MypageEvent<MyShelterEvent | MyVolunteerEvent>,
+      unknown
+    >
+  >;
   shelterFilter: Record<string, VolunteerFilter | ShelterFilter>;
 }
 

--- a/src/providers/AuthContext.tsx
+++ b/src/providers/AuthContext.tsx
@@ -71,16 +71,19 @@ const AuthContext = createContext<AuthContextProps>({
   logout: () => {}
 });
 
-const AuthProvider = ({ children }: PropsWithChildren) => {
+const AuthProvider = ({
+  token,
+  children
+}: PropsWithChildren & {
+  token: string | null;
+}) => {
   const [authState, setAuthState] = useState(initialAuthState);
   const router = useRouter();
   const pathname = usePathname();
 
   useEffect(() => {
-    const dangle_access_token = cookie.get(COOKIE_ACCESS_TOKEN_KEY);
-
-    if (dangle_access_token) {
-      const decoded = jwt.decode(dangle_access_token);
+    if (token) {
+      const decoded = jwt.decode(token);
       const isDecodeToken = (decoded: any): decoded is DecodeToken => {
         return (
           decoded &&

--- a/src/providers/AuthContext.tsx
+++ b/src/providers/AuthContext.tsx
@@ -79,11 +79,7 @@ const AuthProvider = ({
   const router = useRouter();
   const pathname = usePathname();
 
-  useEffect(() => {
-    if (initToken && token) {
-      setStore(COOKIE_ACCESS_TOKEN_KEY, initToken);
-    }
-  }, [initToken, token]);
+  initToken && setStore(COOKIE_ACCESS_TOKEN_KEY, initToken);
 
   useEffect(() => {
     if (token) {

--- a/src/types/deploy.d.ts
+++ b/src/types/deploy.d.ts
@@ -1,0 +1,10 @@
+declare namespace NodeJS {
+  interface Process {
+    env: {
+      [x: string]: string | undefined;
+      NEXT_PUBLIC_VERCEL_URL?: string; //vercel preview로 배포되는 URL,
+      NEXT_PUBLIC_VERCEL_ENV?: string; // "preview" | "production" ...
+      NEXT_PUBLIC_VERCEL_BRANCH_URL?: string; //dangledangle-git-<브랜치이름>-dangledangle.vercel.app
+    };
+  }
+}

--- a/src/utils/ky/hooks/afterResponse.ts
+++ b/src/utils/ky/hooks/afterResponse.ts
@@ -1,47 +1,34 @@
 import ky, { AfterResponseHook } from 'ky';
 import Cookies from 'js-cookie';
-import {
-  COOKIE_ACCESS_TOKEN_KEY,
-  COOKIE_REDIRECT_URL,
-  COOKIE_REFRESH_TOKEN_KEY
-} from '@/constants/cookieKeys';
-import { fetchRefresh } from '@/api/auth/volunteer/refresh';
+import { COOKIE_REDIRECT_URL } from '@/constants/cookieKeys';
+import { getRefresh } from '@/api/auth/volunteer/refresh';
 import { ApiErrorResponse } from '@/types/apiTypes';
 import { ExceptionCode } from '@/constants/exceptionCode';
 
-export const retryRequestOnUnauthorized: AfterResponseHook = async (
-  request,
-  options,
-  response
-) => {
-  const data = await response.json();
+type AfterResponseHookWithProcess = (
+  process: NodeJS.Process
+) => AfterResponseHook;
 
-  if (data.exceptionCode === ExceptionCode.UNAUTHENTICATED) {
-    const accessToken = Cookies.get(COOKIE_ACCESS_TOKEN_KEY);
-    const refreshToken = Cookies.get(COOKIE_REFRESH_TOKEN_KEY);
-
-    if (!accessToken || !refreshToken) {
-      throw new Error('Access token or refresh token is missing');
+export const retryRequestOnUnauthorized: AfterResponseHookWithProcess =
+  process => async (request, options, response) => {
+    console.log('ky에서 에러를잡자', response);
+    if (
+      !(process.env?.NEXT_RUNTIME === 'nodejs') &&
+      !(process.env?.NEXT_RUNTIME === 'edge')
+    ) {
+      const data = await response.json();
+      console.log(data, 'data');
+      if (data.exceptionCode === ExceptionCode.UNAUTHENTICATED) {
+        const data = await getRefresh();
+        if (data.success === true) {
+          return ky(request, options);
+        } else {
+          window.location.href = '/login';
+          return;
+        }
+      }
     }
-
-    const payload = {
-      accessToken,
-      refreshToken
-    };
-
-    Cookies.remove(COOKIE_ACCESS_TOKEN_KEY);
-    Cookies.remove(COOKIE_REFRESH_TOKEN_KEY);
-    const data = await fetchRefresh(payload);
-
-    const newAccessToken = data.accessToken;
-    const newRefreshToken = data.refreshToken;
-
-    Cookies.set(COOKIE_ACCESS_TOKEN_KEY, newAccessToken);
-    Cookies.set(COOKIE_REFRESH_TOKEN_KEY, newRefreshToken);
-
-    return ky(request, options);
-  }
-};
+  };
 
 /** api 요청 과정에서 에러 발생시
  *  ky 에러가 아닌 서버에서 전달받은 에러 throw

--- a/src/utils/ky/hooks/afterResponse.ts
+++ b/src/utils/ky/hooks/afterResponse.ts
@@ -4,6 +4,7 @@ import { COOKIE_REDIRECT_URL } from '@/constants/cookieKeys';
 import { getRefresh } from '@/api/auth/volunteer/refresh';
 import { ApiErrorResponse } from '@/types/apiTypes';
 import { ExceptionCode } from '@/constants/exceptionCode';
+import { runtimeCheck } from '@/utils/runtimeCheck';
 
 type AfterResponseHookWithProcess = (
   process: NodeJS.Process
@@ -11,13 +12,8 @@ type AfterResponseHookWithProcess = (
 
 export const retryRequestOnUnauthorized: AfterResponseHookWithProcess =
   process => async (request, options, response) => {
-    console.log('ky에서 에러를잡자', response);
-    if (
-      !(process.env?.NEXT_RUNTIME === 'nodejs') &&
-      !(process.env?.NEXT_RUNTIME === 'edge')
-    ) {
+    if (runtimeCheck() === 'browser') {
       const data = await response.json();
-      console.log(data, 'data');
       if (data.exceptionCode === ExceptionCode.UNAUTHENTICATED) {
         const data = await getRefresh();
         if (data.success === true) {

--- a/src/utils/ky/hooks/beforeRequest.ts
+++ b/src/utils/ky/hooks/beforeRequest.ts
@@ -1,6 +1,7 @@
 import { BeforeRequestHook } from 'ky';
 import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/cookieKeys';
 import { store } from '@/api/instance';
+import { runtimeCheck } from '@/utils/runtimeCheck';
 
 type BeforeRequestHookWithProcess = (
   process: NodeJS.Process
@@ -8,16 +9,13 @@ type BeforeRequestHookWithProcess = (
 
 export const setAuthorizationHeader: BeforeRequestHookWithProcess =
   process => async (request, options) => {
-    if (
-      !(process.env?.NEXT_RUNTIME === 'nodejs') &&
-      !(process.env?.NEXT_RUNTIME === 'edge')
-    ) {
+    if (runtimeCheck() === 'browser') {
       const accessToken = store[COOKIE_ACCESS_TOKEN_KEY];
       if (accessToken) {
         request.headers.delete('Authorization');
         request.headers.set('Authorization', `Bearer ${accessToken}`);
       } else {
-        throw new Error('accessToken is not exist');
+        throw new Error('beforeRequest, accessToken is not exist');
       }
     }
   };

--- a/src/utils/ky/hooks/beforeRequest.ts
+++ b/src/utils/ky/hooks/beforeRequest.ts
@@ -1,6 +1,7 @@
 import { BeforeRequestHook } from 'ky';
 import Cookies from 'js-cookie';
 import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/cookieKeys';
+import { store } from '@/api/instance';
 
 type BeforeRequestHookWithProcess = (
   process: NodeJS.Process
@@ -8,11 +9,21 @@ type BeforeRequestHookWithProcess = (
 
 export const setAuthorizationHeader: BeforeRequestHookWithProcess =
   process => async (request, options) => {
-    if (process.env?.NEXT_RUNTIME === 'nodejs') return;
-
-    const accessToken = Cookies.get(COOKIE_ACCESS_TOKEN_KEY);
-
-    if (accessToken)
-      request.headers.set('Authorization', `Bearer ${accessToken}`);
-    else request.headers.delete('Authorization');
+    if (
+      process.env?.NEXT_RUNTIME === 'nodejs' ||
+      process.env?.NEXT_RUNTIME === 'edge'
+    ) {
+      const accessToken = store[COOKIE_ACCESS_TOKEN_KEY];
+      if (accessToken) {
+        request.headers.set('Authorization', `Bearer ${accessToken}`);
+      }
+      return;
+    } else {
+      const accessToken = Cookies.get(COOKIE_ACCESS_TOKEN_KEY);
+      if (accessToken) {
+        request.headers.set('Authorization', `Bearer ${accessToken}`);
+      } else {
+        request.headers.delete('Authorization');
+      }
+    }
   };

--- a/src/utils/ky/hooks/beforeRequest.ts
+++ b/src/utils/ky/hooks/beforeRequest.ts
@@ -1,5 +1,4 @@
 import { BeforeRequestHook } from 'ky';
-import Cookies from 'js-cookie';
 import { COOKIE_ACCESS_TOKEN_KEY } from '@/constants/cookieKeys';
 import { store } from '@/api/instance';
 
@@ -10,20 +9,15 @@ type BeforeRequestHookWithProcess = (
 export const setAuthorizationHeader: BeforeRequestHookWithProcess =
   process => async (request, options) => {
     if (
-      process.env?.NEXT_RUNTIME === 'nodejs' ||
-      process.env?.NEXT_RUNTIME === 'edge'
+      !(process.env?.NEXT_RUNTIME === 'nodejs') &&
+      !(process.env?.NEXT_RUNTIME === 'edge')
     ) {
       const accessToken = store[COOKIE_ACCESS_TOKEN_KEY];
       if (accessToken) {
-        request.headers.set('Authorization', `Bearer ${accessToken}`);
-      }
-      return;
-    } else {
-      const accessToken = Cookies.get(COOKIE_ACCESS_TOKEN_KEY);
-      if (accessToken) {
+        request.headers.delete('Authorization');
         request.headers.set('Authorization', `Bearer ${accessToken}`);
       } else {
-        request.headers.delete('Authorization');
+        throw new Error('accessToken is not exist');
       }
     }
   };

--- a/src/utils/runtimeCheck.ts
+++ b/src/utils/runtimeCheck.ts
@@ -1,0 +1,10 @@
+type Runtime = 'nodejs' | 'edge' | 'browser';
+
+export function runtimeCheck(): Runtime {
+  const isNodeJS = process?.env.NEXT_RUNTIME === 'nodejs' && 'nodejs';
+  const isEdge = process?.env.NEXT_RUNTIME === 'edge' && 'edge';
+  const isClient = typeof window !== 'undefined' && 'browser';
+
+  const result = [isNodeJS, isEdge, isClient].filter(Boolean)[0] as Runtime;
+  return result;
+}

--- a/src/utils/token/cookieConfig.ts
+++ b/src/utils/token/cookieConfig.ts
@@ -1,0 +1,10 @@
+import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
+import { NextRequest } from 'next/server';
+
+export const getCookieConfig: (
+  req: NextRequest
+) => Partial<ResponseCookie> = req => ({
+  sameSite: 'lax',
+  httpOnly: true,
+  secure: req?.url.match('localhost') ? false : true
+});


### PR DESCRIPTION
## 스크린샷
<img width="445" alt="image" src="https://github.com/YAPP-Github/dangledangle-client/assets/66112027/ec8c3f61-0d08-4721-899c-cbbe4f8f0f63">

> 서버에서 권한 필요한 api도 요청 가능하게 구현했습니다!~!~! (사용자 이름 요청 api)

<br>

## Motivation

### 이슈번호

- [YW2-208](https://yapp22-web2.atlassian.net/browse/YW2-208)
- [YW2-204](https://yapp22-web2.atlassian.net/browse/YW2-204)
- [YW2-205](https://yapp22-web2.atlassian.net/browse/YW2-205)

### 기존에 존재하던 로그인 관련 문제

1. 보안 이슈

기존 구현방식은 api에서 전달받은 엑세스토큰 및 리프레시토큰을 쿠키에 담아 저장하되 `httponly` 설정을 추가하지 않는 방식으로, 클라이언트 사이드에서 js로 쿠키의 값을 읽고 Authorization 헤더나 Authcontext에 토큰값을 저장하는 방식이었는데요
이 방식의 경우 js를 통한 xss공격을 막을 수 없기 때문에 반드시 수정되어야 했습니다.

2. 서버에서도 인증 토큰이 필요한 이슈

홈 화면에서는 사용자에 따라 다른 정보를 보여주게 되는데요("~~"님 안녕하세요) 해당 데이터는 api 서버에 요청해야 합니다.   
기존 구현방식은 클라이언트 사이드에서 api서버로의 요청을 통해 화면에 해당 정보를 보여줄 수는 있었지만, api 요청을 통해 데이터를 받아오기 전까지는 스켈레톤이나 로그인 되지 않은 화면을 보여주고, api요청이 끝난 이후에서야 해당 정보를 보여주게 되는데 그 이유로 화면이 깜빡이는 현상이 발생했었습니다.    
따라서 서버사이드에서 먼저 api서버로의 요청을 통해 먼저 데이터를 받는 방식을 수행하고자 했습니다.

문제는 엑세스토큰이 필요한 api가 있는데 next 서버에는 유저의 access 토큰을 저장하지 않는다는 점이었는데요, 이 부분을 해결하기 위해 서버에서도 인증 토큰을 사용할 수 있도록 구현해야 했습니다.


<br>

## To Reviewers

### 수정된 로그인 과정 플로우 설명

로그인, 로그아웃 과정에서 반드시 fe 서버를 지나게 됩니다

- 봉사자 로그인(카카오 oauth)
  
  1. 카카오 로그인 버튼 클릭       
  2. 사용자는 카카오 로그인        
  3. 로그인 완료 시 `api서버`는 `/volunteer/redirect`의 파라미터로 authToken 전달     
  4. `next서버`는 전달받은 authToken을 통해 `api서버`로 엑세스 토큰 요청      
  5. `next서버`는 응답받은 엑세스토큰, 리프레시토큰 쿠키에 세팅 및 308 코드로 리다이렉트 함으로써 새로고침 유도
      

- 보호소 로그인

  1. 사용자가 아이디 패스워드 입력, (이때 api 요청을 `api서버`로 보내지 않고 `next서버`로 함)
  2. `next서버는` payload로 온 아이디 패스워드 가지고 `api서버`로 로그인요청
  3. 로그인 완료 시, 전달받은 엑세스토큰, 리프레시토큰 쿠키에 세팅 및 308 코드로 리다이렉트

로그인이 완료되면 사용자 클라이언트에서 `next서버`로 페이지 리소스를 요청할때 항상 쿠키가 전달되므로 next서버는 쿠키에서 엑세스토큰을 읽고 `api`요청에 사용할 수 있습니다.


### src/layout.tsx에서 엑세스토큰 값을 `<AuthProvider />`에 props로 전달

- 이 과정을 통해서, 클라이언트 사이드에서는 쿠키를 사용하지 않으면서도 엑세스토큰을 사용할 수 있습니다.

### ky BeforeRequest hook에서의 Authorization 헤더 설정

- `<AuthProvider />` 에서는 엑세스토큰을 Props로 받게되는데요, 이 토큰을 store라고 이름 붙인 그냥 export 된 객체에 저장합니다. 그리고 ky beforeRequest 훅에서는 해당 store안의 액세스토큰을 Authorization 헤더에 추가해줌으로써 api 요청에 자동으로 엑세스토큰을 추가합니다

- ky의 `api` 인스턴스가 서버사이드에서도 사용되고 있으므로, `checkRuntime()`  유틸함수를 통해 해당 ky 인스턴스가 실행되고 있는 곳이 어디인지 먼저 체크한 뒤, 클라이언트 사이드에서만 Authrorization 헤더를 추가하도록 했습니다.

- 현재 서버사이드에서 api를 요청할때는 따로 ky hook에서 처리해주고 있지 않은데요(매번 옵션의 headers에 추가), `store` 객체를 클라이언트와 서버에서 공유하지 않고 있어서, 위와 같은 방식으로 처리할 수 없었습니다. 이부분은 추후 수정해보겠습니다



### api 서버로의 요청과 next 서버로의 요청 구분

- prefixUrl을 보면 알 수 있듯 ky 인스턴스 중 `api` 는 api 서버로, `fe`는 next 서버를 향하고 있습니다. 추후 기능 개발시 참고 부탁드립니다~


