### PR TITLE
[Update] 마이페이지 SSR 처리 및 보호소 회원탈퇴 추가

### DIFF
--- a/src/api/mypage/mypage.ts
+++ b/src/api/mypage/mypage.ts
@@ -45,16 +45,16 @@ export interface ShelterResponse {
   shelterId: number;
 }
 
-export const getVolInfo = async () => {
+export const getVolInfo = async (option?: Options) => {
   const response = await api
-    .get(`volunteer/my`)
+    .get(`volunteer/my`, option)
     .then(res => res.json<MyVolInfo>());
   return response;
 };
 
-export const getShelterInfo = async () => {
+export const getShelterInfo = async (option?: Options) => {
   const response = await api
-    .get(`shelter/admin/my`)
+    .get(`shelter/admin/my`, option)
     .then(res => res.json<MyShelterInfo>());
   return response;
 };

--- a/src/api/shelter/admin/useDeleteVolunteerEvent.ts
+++ b/src/api/shelter/admin/useDeleteVolunteerEvent.ts
@@ -19,9 +19,7 @@ export default function useDeleteVolunteerEvent(
     {
       onSuccess: (data, variables, context) => {
         options?.onSuccess && options.onSuccess(data, variables, context);
-        return queryClient.invalidateQueries(
-          queryKey.list(variables.shelterId)
-        );
+        return queryClient.invalidateQueries();
       },
       ...options
     }

--- a/src/api/volunteer/my/withdraw.ts
+++ b/src/api/volunteer/my/withdraw.ts
@@ -3,3 +3,7 @@ import api from '@/api/instance';
 export const withdraw = async () => {
   return await api.delete('volunteer/my/withdraw').json();
 };
+
+export const shelterWithdraw = async () => {
+  return await api.delete('shelter/admin/my/withdraw').json();
+};

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -5,16 +5,40 @@ import MyPageMain from '../../components/mypage/MyPageMain/MyPageMain';
 import ToggleSection from '@/components/mypage/MyPageMain/ToggleSection';
 import MyPageHistory from '@/components/mypage/MyPageMain/MyPageHistory';
 import * as styles from './styles.css';
+import getQueryClient from '@/providers/getQueryClient';
+import { getShelterInfo, getVolInfo, queryKey } from '@/api/mypage/mypage';
+import { dehydrate } from '@tanstack/query-core';
+import Hydrate from '@/providers/Hydrate';
 
-export default function AdminMyPage() {
+export default async function AdminMyPage() {
   const accessToken = cookies().get(COOKIE_ACCESS_TOKEN_KEY)?.value || '';
   const { dangle_role: role } = decodeDangleToken(accessToken);
   const isShelterRole = role === 'SHELTER' ? true : false;
+  const headerOption = {
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  };
+
+  const fetchData = async () => {
+    if (role === 'SHELTER') {
+      return await getShelterInfo(headerOption);
+    } else {
+      return await getVolInfo(headerOption);
+    }
+  };
+
+  const queryClient = getQueryClient();
+  await queryClient.prefetchQuery(queryKey.all, fetchData);
+  const dehydratedState = dehydrate(queryClient);
+
   return (
     <div className={styles.wrapper}>
-      <MyPageHistory isShelterRole={isShelterRole} dangle_role={role} />
-      <ToggleSection isShelterRole={isShelterRole} dangle_role={role} />
-      <MyPageMain isShelterRole={isShelterRole} dangle_role={role} />
+      <Hydrate state={dehydratedState}>
+        <MyPageHistory isShelterRole={isShelterRole} dangle_role={role} />
+        <ToggleSection isShelterRole={isShelterRole} dangle_role={role} />
+        <MyPageMain isShelterRole={isShelterRole} dangle_role={role} />
+      </Hydrate>
     </div>
   );
 }

--- a/src/components/shelter-event/VolunteerEventPage/VolunteerEventPage.tsx
+++ b/src/components/shelter-event/VolunteerEventPage/VolunteerEventPage.tsx
@@ -41,7 +41,7 @@ export default function VolunteerEventPage({
           deleteEvent({ shelterId, volunteerEventId }).then(() => {
             dialogOff();
             toastOn('이벤트가 삭제되었습니다.');
-            router.push(`/shelter/${shelterId}`);
+            router.back();
           });
         }
       }

--- a/src/components/unregister/Unregister.tsx
+++ b/src/components/unregister/Unregister.tsx
@@ -13,7 +13,7 @@ import { UserRole } from '@/constants/user';
 import { MyShelterInfo, MyVolInfo } from '@/api/mypage/mypage';
 import LoadingIndicator from '../common/Button/LoadingIndicator';
 import { useRouter } from 'next/navigation';
-import { withdraw } from '@/api/volunteer/my/withdraw';
+import { shelterWithdraw, withdraw } from '@/api/volunteer/my/withdraw';
 import useLogout from '@/api/mypage/useLogout';
 
 interface UnregisterProps {
@@ -36,8 +36,7 @@ export default function Unregister({ role }: UnregisterProps) {
     console.log(12123);
 
     if (role === 'SHELTER') {
-      //TODO: 보호소 탈퇴 api 호출
-      console.log('보호소 탈퇴');
+      await shelterWithdraw();
     } else {
       await withdraw();
     }

--- a/src/providers/AuthContext.tsx
+++ b/src/providers/AuthContext.tsx
@@ -100,13 +100,13 @@ const AuthProvider = ({
 
         setAuthState((prevState: AuthState) => ({
           ...prevState,
-          dangle_access_token,
+          dangle_access_token: initToken,
           dangle_id: decodedToken.id,
           dangle_role: decodedToken.role
         }));
       }
     }
-  }, [router, pathname, token]);
+  }, [router, pathname, token, initToken]);
 
   const logout = useCallback(() => {
     setAuthState(initialAuthState);


### PR DESCRIPTION
### Key Changes

- authContext의 authState accessToken에 initToken 바인딩 했습니다.
- mypage 정보 SSR 처리하였습니다.
- 회원탈퇴 로직에 보호소 용 로직 추가했습니다.
- 이벤트 삭제 시 router.push => router.back 변경했습니다.