### PR TITLE
[Fix] 보호소 로그인 에러 수정

### DIFF
--- a/src/api/shelter/auth/useShelterLogin.ts
+++ b/src/api/shelter/auth/useShelterLogin.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { LoginPayload } from './login';
 import { ApiErrorResponse } from '@/types/apiTypes';
 import { fe } from '@/api/instance';
+import { decrypt, encrypt } from '@/utils/passwordCrypto';
 
 export const shelterAuthKey = {
   all: ['shelterAuth'] as const
@@ -12,9 +13,18 @@ export type ShelterLoginResponse = {
 };
 
 const shelterLoginAPI = async (data: LoginPayload) => {
+  const { email, password } = data;
+  const encryptedPassword = encrypt(
+    password,
+    process.env.NEXT_PUBLIC_ENCRYPT_SECRET!
+  );
+
   const response = await fe
     .post(`auth/shelter/login`, {
-      json: data
+      json: {
+        email,
+        password: encryptedPassword
+      }
     })
     .then(res => res.json<ShelterLoginResponse>());
 

--- a/src/app/api/auth/shelter/login/route.ts
+++ b/src/app/api/auth/shelter/login/route.ts
@@ -3,15 +3,20 @@ import {
   COOKIE_ACCESS_TOKEN_KEY,
   COOKIE_REFRESH_TOKEN_KEY
 } from '@/constants/cookieKeys';
+import { decrypt } from '@/utils/passwordCrypto';
 import { getCookieConfig } from '@/utils/token/cookieConfig';
-import { ResponseCookie } from 'next/dist/compiled/@edge-runtime/cookies';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
   const cookies = req.cookies;
   const redirectPath = cookies.get('redirectUrl')?.value || '/';
   const redirectTo = `${req.nextUrl.origin}${decodeURIComponent(redirectPath)}`;
-  const { email = '', password = '' } = await req.json();
+  const { email = '', password: encryptedPassword = '' } = await req.json();
+
+  const password = decrypt(
+    encryptedPassword,
+    process.env.NEXT_PUBLIC_ENCRYPT_SECRET!
+  );
 
   try {
     if (!email || !password) {

--- a/src/app/register/shelter/components/RequireComplete.tsx
+++ b/src/app/register/shelter/components/RequireComplete.tsx
@@ -4,9 +4,22 @@ import Image from 'next/image';
 import { OnNextProps } from '../page';
 import * as styles from './../styles.css';
 import useHeader from '@/hooks/useHeader';
+import { useFormContext } from 'react-hook-form';
+import { MouseEventHandler } from 'react';
 
-export default function RequireComplete({ onNext }: OnNextProps) {
+export default function RequireComplete({ onLogin }: OnNextProps) {
   useHeader({ isHeader: 'hidden' });
+
+  const { watch } = useFormContext();
+
+  const emailValue = watch('email');
+  const passwordValue = watch('password');
+
+  const handleLogin: MouseEventHandler<HTMLButtonElement> = e => {
+    e.preventDefault();
+    onLogin({ email: emailValue, password: passwordValue });
+  };
+
   return (
     <div className={styles.complete}>
       <Image
@@ -19,7 +32,7 @@ export default function RequireComplete({ onNext }: OnNextProps) {
       <H3 color="gray600" style={{ textAlign: 'center' }}>
         댕글댕글에 오신 것을 환영해요!
       </H3>
-      <Button onClick={onNext} style={{ marginTop: '152px' }}>
+      <Button onClick={handleLogin} style={{ marginTop: '152px' }}>
         다음
       </Button>
     </div>

--- a/src/app/register/shelter/page.tsx
+++ b/src/app/register/shelter/page.tsx
@@ -22,10 +22,14 @@ import SpecificAddress from './components/SpecificAddress';
 import Sure from './components/Sure';
 import { registerValidation } from '@/app/shelter/utils/shelterValidaion';
 import useHeader from '@/hooks/useHeader';
+import useShelterLogin from '@/api/shelter/auth/useShelterLogin';
 
 export interface OnNextProps {
   onNext: VoidFunction;
   onSubmit: SubmitHandler<SignUpFormValue>;
+  onLogin: (
+    loginData: Pick<SignUpFormValue, 'email' | 'password'>
+  ) => Promise<void>;
 }
 
 export interface SignUpFormValue extends ShelterRegisterPayload {
@@ -92,7 +96,9 @@ export default function ShelterRegister() {
     resolver: yupResolver(registerValidation)
   });
 
-  const { mutateAsync } = useShelterRegister();
+  const { mutateAsync: registerMutateAsync } = useShelterRegister();
+  const { mutateAsync: loginMutateAsync } = useShelterLogin();
+
   const { handleSubmit } = methods;
 
   const onSubmit = useCallback(
@@ -104,19 +110,35 @@ export default function ShelterRegister() {
       };
 
       try {
-        await mutateAsync(newData);
+        await registerMutateAsync(newData);
         goToNextStep();
         toastOn('회원가입에 성공했습니다.');
       } catch (error) {
         toastOn('회원가입에 실패했습니다.');
       }
     },
-    [goToNextStep, toastOn, mutateAsync]
+    [goToNextStep, toastOn, registerMutateAsync]
   );
 
+  const onLogin = useCallback(
+    async (loginData: Pick<SignUpFormValue, 'email' | 'password'>) => {
+      try {
+        await loginMutateAsync(loginData);
+        goToNextStep();
+        toastOn('로그인에 성공했습니다.');
+      } catch (error) {
+        toastOn('로그인에 실패했습니다.');
+      }
+    },
+    [goToNextStep, toastOn, loginMutateAsync]
+  );
   return (
     <FormProvider methods={methods} onSubmit={handleSubmit(onSubmit)}>
-      <CurrentComponent onNext={goToNextStep} onSubmit={onSubmit} />
+      <CurrentComponent
+        onNext={goToNextStep}
+        onSubmit={onSubmit}
+        onLogin={onLogin}
+      />
     </FormProvider>
   );
 }

--- a/src/utils/passwordCrypto.ts
+++ b/src/utils/passwordCrypto.ts
@@ -1,0 +1,37 @@
+import * as crypto from 'crypto';
+
+const createSHA256Hash = (key: string) =>
+  crypto.createHash('sha256').update(key).digest();
+
+// 암호화 함수
+export const encrypt = (text: string, secret: string) => {
+  const key = createSHA256Hash(String(secret));
+
+  const iv = crypto.randomBytes(16);
+
+  const cipher = crypto.createCipheriv('aes-256-cbc', Buffer.from(key), iv);
+  let encrypted = cipher.update(text);
+  encrypted = Buffer.concat([encrypted, cipher.final()]);
+  const result = iv.toString('hex') + ':' + encrypted.toString('hex');
+  return result;
+};
+
+// 복호화 함수
+export const decrypt = (text: string, secret: string) => {
+  const key = createSHA256Hash(String(secret));
+
+  const textParts = text.split(':');
+
+  const ivString = textParts.shift();
+  if (!ivString) throw new Error('암호화된 text 형식이 아닙니다.');
+
+  const iv = Buffer.from(ivString, 'hex');
+  const encryptedText = Buffer.from(textParts.join(':'), 'hex');
+
+  const decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(key), iv);
+  let decrypted = decipher.update(encryptedText);
+  decrypted = Buffer.concat([decrypted, decipher.final()]);
+
+  const result = decrypted.toString();
+  return result;
+};


### PR DESCRIPTION
## Motivation

- 보호소 회원가입 플로우에서 추가 정보 입력시 회원이 로그인 된 상태여야 하므로, 회원가입 완료 후 로그인을 실행하는 로직을 추가했습니다.

- 추가로 클라이언트에서 fe서버로 로그인 시 패스워드가 평문 그대로 전송되고 있었는데 secret 키로 암호화해서 전송하도록 수정했습니다.

<br>

## To Reviewers
